### PR TITLE
[Ubuntu-22] Fix Podman CNI version issue on Ubuntu 22 by installing containernetworking-plugins 1.1.1

### DIFF
--- a/images/ubuntu/scripts/build/install-container-tools.sh
+++ b/images/ubuntu/scripts/build/install-container-tools.sh
@@ -27,6 +27,12 @@ if is_ubuntu20; then
     echo "deb [arch=amd64 signed-by=$GPG_KEY] ${REPO_URL}/ /" > $REPO_PATH
 fi
 
+if is_ubuntu22; then
+    # Install containernetworking-plugins for Ubuntu 22
+    curl -O http://archive.ubuntu.com/ubuntu/pool/universe/g/golang-github-containernetworking-plugins/containernetworking-plugins_1.1.1+ds1-3build1_amd64.deb
+    dpkg -i containernetworking-plugins_1.1.1+ds1-3build1_amd64.deb
+fi
+
 # Install podman, buildah, skopeo container's tools
 apt-get update
 apt-get install ${install_packages[@]}


### PR DESCRIPTION
This PR fixes an issue with Podman on Ubuntu 22, where it was failing due to a problem with the CNI version. The solution is to install containernetworking-plugins version 1.1.1, which resolves the issue and makes Podman work correctly.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
