### PR TITLE
Fix mirror+file: for ubuntu.sources

### DIFF
--- a/images/ubuntu/scripts/build/configure-apt-sources.sh
+++ b/images/ubuntu/scripts/build/configure-apt-sources.sh
@@ -13,12 +13,12 @@ printf "https://archive.ubuntu.com/ubuntu/\tpriority:2\n" | tee -a /etc/apt/apt-
 printf "https://security.ubuntu.com/ubuntu/\tpriority:3\n" | tee -a /etc/apt/apt-mirrors.txt
 
 if is_ubuntu24; then
-    sed -i 's/https:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/apt-mirrors.txt/' /etc/apt/sources.list.d/ubuntu.sources
+    sed -i 's/http:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/apt-mirrors.txt/' /etc/apt/sources.list.d/ubuntu.sources
 
     # Apt changes to survive Cloud Init
     cp -f /etc/apt/sources.list.d/ubuntu.sources  /etc/cloud/templates/sources.list.ubuntu.deb822.tmpl
 else
-    sed -i 's/https:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/apt-mirrors.txt/' /etc/apt/sources.list
+    sed -i 's/http:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/apt-mirrors.txt/' /etc/apt/sources.list
 
     # Apt changes to survive Cloud Init
     cp -f /etc/apt/sources.list /etc/cloud/templates/sources.list.ubuntu.tmpl


### PR DESCRIPTION
> # Description
> Restore search part of search and replace to enable application of `mirror+file:` protocol.
> 
> #### Related issue:
> * [Change URL for packages #11997 (comment)](https://github.com/actions/runner-images/pull/11997#discussion_r2047325056)
> 
> ## Check list
> * [ ]  Related issue / work item is attached
> * [ ]  Tests are written (if applicable)
> * [ ]  Documentation is updated (if applicable)
> * [ ]  Changes are tested and related VM images are successfully generated

