### PR TITLE
[Ubuntu] Update Docker Compose version to 2.36.0

### DIFF
--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -210,7 +210,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.35.1",
+                "version": "2.36.0",
                 "asset": "linux-x86_64"
             }
         ]


### PR DESCRIPTION
# Description
This PR upgrades Docker Compose to version v2.36.0 for the Ubuntu image. it will fix known [bug](https://github.com/docker/compose/issues/12747) in earlier versions of Docker Compose caused issues with parallel operations.

#### Related issue:
#12160

## Check list
* [x]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [ ]  Changes are tested and related VM images are successfully generated

