### PR TITLE
Fix fwupd intergration test on Ubuntu 22.04

### DIFF
--- a/images/ubuntu/scripts/tests/System.Tests.ps1
+++ b/images/ubuntu/scripts/tests/System.Tests.ps1
@@ -9,7 +9,13 @@ Describe "Disk free space" -Skip:(-not [String]::IsNullOrEmpty($env:AGENT_NAME) 
 
 Describe "fwupd removed" {
     It "Is not present on box" {
-        $systemctlOutput = & systemctl list-unit-files fwupd-refresh.timer
-        $systemctlOutput | Should -Match "masked"
+        $systemctlOutput = & systemctl list-unit fwupd-refresh.timer --no-legend
+        # When disabled the output looks like this:
+        #❯ systemctl list-units fwupd-refresh.timer --no-legend
+        #● fwupd-refresh.timer masked failed failed fwupd-refresh.timer
+        # When enabled the output looks like this:
+        #❯ systemctl list-units fwupd-refresh.timer --no-legend
+        #fwupd-refresh.timer loaded active waiting Refresh fwupd metadata regularly
+        $systemctlOutput | Should -Not -Match "active"
     }
 }


### PR DESCRIPTION
In Ubuntu 22.04 the timer service isn't present. In which case we should not do the match.

See:

* [Bug: Mask `fwupd` timer on ubuntu images #12225 (comment)](https://github.com/actions/runner-images/pull/12225#issuecomment-2904383955)

# Description
New tool, Bug fixing, or Improvement? Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. **For new tools, please provide total size and installation time.**

#### Related issue:
## Check list
* [ ]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [ ]  Changes are tested and related VM images are successfully generated

