### PR TITLE
Ignore request from Dependabot

### DIFF
--- a/.github/workflows/tools_linter.yml
+++ b/.github/workflows/tools_linter.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     name: Lint JSON & MD files
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
# Description
All requests made by dependabot should be ignored or skipped.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
