### PR TITLE
[Ubuntu] Update Maven to 3.9.10 to fix 404 error

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -70,7 +70,7 @@
     "java": {
         "default": "11",
         "versions": [ "8", "11", "17", "21"],
-        "maven": "3.9.9"
+        "maven": "3.9.10"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -67,7 +67,7 @@
     "java": {
         "default": "17",
         "versions": [ "8", "11", "17", "21"],
-        "maven": "3.9.9"
+        "maven": "3.9.10"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",


### PR DESCRIPTION
This PR updates the Maven version from 3.9.9 to 3.9.10. Maven 3.9.9 is no longer available in the official Maven repository and results in a 404 error during builds. Upgrading to 3.9.10 resolves this issue and Image generation issue.

#### Related issue:
#12334

## Check list
* [x]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [x]  Changes are tested and related VM images are successfully generated