### PR TITLE
[Ubuntu] Updated docker-compose to 2.36.2

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -250,7 +250,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.35.1",
+                "version": "2.36.2",
                 "asset": "linux-x86_64"
             }
         ]

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -210,7 +210,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.36.0",
+                "version": "2.36.2",
                 "asset": "linux-x86_64"
             }
         ]


### PR DESCRIPTION
This PR updates the docker-compose version to 2.36.2 in Ubuntu 22.04 and 24.04

#### Related issue: #12289
## Check list
* [x]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [ ]  Changes are tested and related VM images are successfully generated
