### PR TITLE
CodeQL: install platform specific CodeQL bundle

### DIFF
--- a/images/ubuntu/scripts/build/install-codeql-bundle.sh
+++ b/images/ubuntu/scripts/build/install-codeql-bundle.sh
@@ -30,7 +30,7 @@ bundle_tag_name="codeql-bundle-v$bundle_version"
 echo "Downloading CodeQL bundle $bundle_version..."
 # Note that this is the all-platforms CodeQL bundle, to support scenarios where customers run
 # different operating systems within containers.
-codeql_archive=$(download_with_retry "https://github.com/github/codeql-action/releases/download/$bundle_tag_name/codeql-bundle.tar.gz")
+codeql_archive=$(download_with_retry "https://github.com/github/codeql-action/releases/download/$bundle_tag_name/codeql-bundle-linux64.tar.gz")
 
 codeql_toolcache_path="$AGENT_TOOLSDIRECTORY/CodeQL/$bundle_version/x64"
 mkdir -p "$codeql_toolcache_path"


### PR DESCRIPTION
This should reduce the size of the CodeQL bundle by only including the platform specific CodeQL CLI and libraries, rather than the full set of CodeQL CLI and libraries for all platforms.

# Description
New tool, Bug fixing, or Improvement? Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. **For new tools, please provide total size and installation time.**

#### Related issue:
## Check list
* [ ]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [ ]  Changes are tested and related VM images are successfully generated