### PR TITLE
[Ubuntu, Windows] Update edgedriver URL and maven version on ubuntu

### DIFF
--- a/images/ubuntu/scripts/build/install-microsoft-edge.sh
+++ b/images/ubuntu/scripts/build/install-microsoft-edge.sh
@@ -34,11 +34,11 @@ mkdir -p $EDGEDRIVER_DIR
 edge_version=$(microsoft-edge --version | cut -d' ' -f 3)
 edge_version_major=$(echo $edge_version | cut -d'.' -f 1)
 
-edgedriver_version_url="https://msedgedriver.azureedge.net/LATEST_RELEASE_${edge_version_major}_LINUX"
+edgedriver_version_url="https://msedgedriver.microsoft.com/LATEST_RELEASE_${edge_version_major}_LINUX"
 # Convert a resulting file to normal UTF-8
 edgedriver_latest_version=$(curl -fsSL "$edgedriver_version_url" | iconv -f utf-16 -t utf-8 | tr -d '\r')
 
-edgedriver_url="https://msedgedriver.azureedge.net/${edgedriver_latest_version}/edgedriver_linux64.zip"
+edgedriver_url="https://msedgedriver.microsoft.com/${edgedriver_latest_version}/edgedriver_linux64.zip"
 edgedriver_archive_path=$(download_with_retry "$edgedriver_url")
 
 unzip -qq "$edgedriver_archive_path" -d "$EDGEDRIVER_DIR"

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -70,7 +70,7 @@
     "java": {
         "default": "11",
         "versions": [ "8", "11", "17", "21"],
-        "maven": "3.9.10"
+        "maven": "3.9.11"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -67,7 +67,7 @@
     "java": {
         "default": "17",
         "versions": [ "8", "11", "17", "21"],
-        "maven": "3.9.10"
+        "maven": "3.9.11"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",


### PR DESCRIPTION
# Description
* This PR will updates the url of edgedriver from msedgedriver.azureedge.net to msedgedriver.microsoft.com  in both ubuntu and Windows images.
* Maven version to 3.9.11 in Ubuntu images

#### Related issue:
#12597

## Check list
* [x]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [ ]  Changes are tested and related VM images are successfully generated

