### PR TITLE
Added PACKER_GITHUB_API_TOKEN for higher rate limit

### DIFF
--- a/.github/workflows/ubuntu_trigger-build-new-templates.yml
+++ b/.github/workflows/ubuntu_trigger-build-new-templates.yml
@@ -90,6 +90,8 @@ jobs:
       - name: Run `packer init`
         id: init
         run: packer init ./images/ubuntu/templates/${{ inputs.hcl_filename }}
+        env:
+          PACKER_GITHUB_API_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Run `packer validate`
         id: validate
@@ -101,6 +103,7 @@ jobs:
           HCLOUD_SERVER_IMAGE: ${{ inputs.hcloud_server_image }}
           HCLOUD_SERVER_TYPE: ${{ inputs.hcloud_server_type }}
           IMAGE_VERSION: ${{ inputs.release_no }}
+          PACKER_GITHUB_API_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Run `packer build`
         id: build
@@ -113,6 +116,8 @@ jobs:
           HCLOUD_SERVER_TYPE: ${{ inputs.hcloud_server_type }}
           IMAGE_VERSION: ${{ inputs.release_no }}
           PACKER_LOG: ${{ vars.PACKER_LOG }}
+          PACKER_GITHUB_API_TOKEN: ${{ steps.generate-token.outputs.token }}
+          
           
       - name: Upload file software-report.json to artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Description
Avoid rate limit when fetching Packer plugins by using GitHub API token.

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [x] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
