### PR TITLE
[Ubuntu 22] Removing .Net-sdk-6.0 and .Net version 6.0

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -267,12 +267,10 @@
     ],
     "dotnet": {
         "aptPackages": [
-            "dotnet-sdk-6.0",
             "dotnet-sdk-8.0",
             "dotnet-sdk-9.0"
         ],
         "versions": [
-            "6.0",
             "8.0",
             "9.0"
         ],


### PR DESCRIPTION
# Description
This PR will remove the .Net-sdk-6.0 and .Net version 6.0

#### Related issue:
Related Announcement: #12241

## Check list
* [x]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [ ]  Changes are tested and related VM images are successfully generated