### PR TITLE
[Ubuntu] update docker-compose to v2.37.3

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -250,7 +250,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.36.2",
+                "version": "2.37.3",
                 "asset": "linux-x86_64"
             }
         ]

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -210,7 +210,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.36.2",
+                "version": "2.37.3",
                 "asset": "linux-x86_64"
             }
         ]


### PR DESCRIPTION
This PR will update the docker compose version to v2.37.3 in Ubuntu images

#### Related issue:#12649
## Check list
* [x]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [ ]  Changes are tested and related VM images are successfully generated