### PR TITLE
[all OSs] Pin Rust to 1.89.0 due to a 1.90.0 breaking change

### DIFF
--- a/images/ubuntu/scripts/build/install-rust.sh
+++ b/images/ubuntu/scripts/build/install-rust.sh
@@ -11,7 +11,8 @@ source $HELPER_SCRIPTS/os.sh
 export RUSTUP_HOME=/etc/skel/.rustup
 export CARGO_HOME=/etc/skel/.cargo
 
-curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable --profile=minimal
+# Pin to 1.89.0 until https://github.com/actions/runner-images/issues/13041 && https://github.com/rust-lang/rust/issues/145936 is resolved
+curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.89.0 --profile=minimal
 
 # Initialize environment variables
 source $CARGO_HOME/env


### PR DESCRIPTION
[all OSs] Pin Rust to 1.89.0 due to a 1.90.0 breaking change


# Description
Initially reported issue highlights upcoming breaking change. Let's pin current version until some information on that behaviour provided in the developers repo: [rust-lang/rust#145936](https://github.com/rust-lang/rust/issues/145936)

#### Related issue:
#13041

## Check list
* [x]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [ ]  Changes are tested and related VM images are successfully generated
