### PR TITLE
[ubuntu] Fix tools version extraction in Install Android SDK scripts

### DIFF
--- a/images/ubuntu/scripts/build/install-android-sdk.sh
+++ b/images/ubuntu/scripts/build/install-android-sdk.sh
@@ -15,8 +15,8 @@ add_filtered_installation_components() {
     local tools_array=("$@")
 
     for item in ${tools_array[@]}; do
-        # Take the last argument after splitting string by ';'' and '-''
-        item_version=$(echo "${item##*[-;]}")
+        # Take the last version number that appears after the last '-' or ';'
+        item_version=$(echo "$item" | grep -oE '[-;][0-9.]+' | grep -oE '[0-9.]+')
 
         # Semver 'comparison'. Add item to components array, if item's version is greater than or equal to minimum version
         if [[ "$(printf "${minimum_version}\n${item_version}\n" | sort -V | head -n1)" == "$minimum_version" ]]; then


### PR DESCRIPTION
Modify version extraction logic to capture the last version number after '-' or ';'.

# Description
Bug fixing

This change updates the method for parsing the version number for Android platform tools.

The previous method used shell parameter expansion (`${item##*[-;]}`) to get the string segment after the last `-` or `;`. This approach failed for tool names with extensions, such as `platforms;android-33-ext4`, where it would incorrectly extract `ext4` instead of the actual version, `33`.

For example current full list of tools_array is:

```
tools_array=('platforms;android-10' 'platforms;android-11' 'platforms;android-12' 'platforms;android-13' 'platforms;android-14' 'platforms;android-15' 'platforms;android-16' 'platforms;android-17' 'platforms;android-18' 'platforms;android-19' 'platforms;android-20' 'platforms;android-21' 'platforms;android-22' 'platforms;android-23' 'platforms;android-24' 'platforms;android-25' 'platforms;android-26' 'platforms;android-27' 'platforms;android-28' 'platforms;android-29' 'platforms;android-30' 'platforms;android-31' 'platforms;android-32' 'platforms;android-33' 'platforms;android-33-ext4' 'platforms;android-33-ext5' 'platforms;android-34' 'platforms;android-34-ext10' 'platforms;android-34-ext11' 'platforms;android-34-ext12' 'platforms;android-34-ext8' 'platforms;android-35' 'platforms;android-35-ext14' 'platforms;android-35-ext15' 'platforms;android-36' 'platforms;android-36-ext18' 'platforms;android-7' 'platforms;android-8' 'platforms;android-9')
```

#### Related issue:
## Check list
* [ ]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [ ]  Changes are tested and related VM images are successfully generated

