### PR TITLE
Add provisioner shell to list installed apt packages

### DIFF
--- a/images/ubuntu/scripts/build/list-dpkg.sh
+++ b/images/ubuntu/scripts/build/list-dpkg.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+################################################################################
+##  File:  list-dpkg.sh
+##  Desc:  List all installed dpkg packages
+################################################################################
+
+echo "Listing all installed dpkg packages..."
+dpkg-query -W -f='${Package} ${Version}\n' | sort

--- a/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
@@ -305,6 +305,11 @@ build {
   }
 
   provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    script          = "${path.root}/../scripts/build/list-dpkg.sh"
+  }
+
+  provisioner "shell" {
     execute_command   = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     expect_disconnect = true
     inline            = ["echo 'Reboot VM'", "sudo reboot"]

--- a/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
@@ -285,6 +285,11 @@ build {
   }
 
   provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    script          = "${path.root}/../scripts/build/list-dpkg.sh"
+  }
+
+  provisioner "shell" {
     execute_command   = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     expect_disconnect = true
     inline            = ["echo 'Reboot VM'", "sudo reboot"]


### PR DESCRIPTION
# Description
This PR adds a new step to the Ubuntu 22.04 and 24.04 image build pipelines to output a sorted list of installed apt packages and their versions.

#### Related issue: N/A
## Check list
* [x]  Related issue / work item is attached
* [x]  Documentation is updated (if applicable)

