### PR TITLE
Fix ubuntu-slim Dockerfile to configure sources beforehand

### DIFF
--- a/images/ubuntu-slim/Dockerfile
+++ b/images/ubuntu-slim/Dockerfile
@@ -27,8 +27,8 @@ RUN chmod +x /opt/entrypoint.sh
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y sudo lsb-release jq dpkg && \
     touch /run/.containerenv && \
-    /tmp/scripts/build/configure-apt.sh && \
     /tmp/scripts/build/configure-apt-sources.sh && \
+    /tmp/scripts/build/configure-apt.sh && \
     /tmp/scripts/build/install-apt-vital.sh && \
     /tmp/scripts/build/install-ms-repos.sh && \
     /tmp/scripts/build/configure-image-data-file.sh && \


### PR DESCRIPTION
# Description
`scripts/build/configure-apt.sh` runs `apt install` and it should have sources configured beforehand.

Reference:

* https://github.com/actions/runner-images/blob/eed8f1849557178dce62399a47f68e02b7778071/images/ubuntu/templates/build.ubuntu-22_04.pkr.hcl#L25
* https://github.com/actions/runner-images/blob/eed8f1849557178dce62399a47f68e02b7778071/images/ubuntu/templates/build.ubuntu-24_04.pkr.hcl#L25

#### Related issue: #13426