### PR TITLE
Update configure-apt-mock.sh to enable parallelism

### DIFF
--- a/images/ubuntu/scripts/build/configure-apt-mock.sh
+++ b/images/ubuntu/scripts/build/configure-apt-mock.sh
@@ -26,6 +26,15 @@ while [ \$i -le 30 ];do
   if grep -q 'Could not get lock' \$err;then
     # apt db locked needs retry
     retry=true
+  elif grep -q 'Could not get lock /var/lib/apt/lists/lock' \$err;then
+    # apt update did not complete (race condition), needs retry
+    retry=true
+  elif grep -q 'Problem renaming the file /var/cache/apt/pkgcache.bin.* to /var/cache/apt/pkgcache.bin' \$err;then
+    # apt-get did not complete (race condition), needs retry
+    retry=true
+  elif grep -q 'Problem renaming the file /var/cache/apt/srcpkgcache.bin.* to /var/cache/apt/srcpkgcache.bin' \$err;then
+    # apt update did not complete (race condition), needs retry
+    retry=true
   elif grep -q 'Could not open file /var/lib/apt/lists' \$err;then
     # apt update is not completed, needs retry
     retry=true


### PR DESCRIPTION
# Description
This adds a few errors that happen when another update/install process is running in parallel. `apt-get update` doesn't handle race conditions well, and `apt-get install` has one as well.

This is pre-cursor to another change that enables parallelism in the packer templates to run the `install-*.sh` scripts parallel, as I mentioned in https://github.com/actions/runner-images/discussions/2320

On its own, this change does nothing, except maybe slightly increase reliability of image building.

## Check list
* [n/a] Related issue / work item is attached
* [n/a] Tests are written (if applicable)
* [n/a] Documentation is updated (if applicable)
* [n/a] Changes are tested and related VM images are successfully generated