### PR TITLE
Configure USE_BAZEL_FALLBACK_VERSION for Bazelisk

### DIFF
--- a/images/ubuntu/scripts/build/install-bazel.sh
+++ b/images/ubuntu/scripts/build/install-bazel.sh
@@ -6,11 +6,19 @@
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
+source $HELPER_SCRIPTS/etc-environment.sh
 
 # Install bazelisk
 npm install -g @bazel/bazelisk
 
-# run bazelisk once in order to install /usr/local/bin/bazel binary
-sudo -u $SUDO_USER bazel version
+# Run bazelisk once in order to install /usr/local/bin/bazel binary
+bazel version
+
+# Get the installed Bazel version from bazelisk
+BAZEL_VERSION=$(bazel --version | grep "Build label:" | awk '{print $3}')
+
+# Set USE_BAZEL_FALLBACK_VERSION so that users without .bazelversion
+# get the preinstalled version instead of downloading latest
+set_etc_environment_variable "USE_BAZEL_FALLBACK_VERSION" "silent:${BAZEL_VERSION}"
 
 invoke_tests "Tools" "Bazel"


### PR DESCRIPTION
Set the pre-installed Bazel version as the fallback so users without a .bazelversion file use the cached binary instead of downloading latest.

# Description
This change writes `USE_BAZEL_FALLBACK_VERSION` to `/etc/environment` during image provisioning. When Bazelisk runs and no version is defined, it uses the pre-installed Bazel binary rather than downloading the latest version.

Reference: https://github.com/bazelbuild/bazelisk#how-does-bazelisk-know-which-bazel-version-to-run

#### Related issue: #13564
## Check list
* [x]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [ ]  Changes are tested and related VM images are successfully generated
