### PR TITLE
Add Hetzner Cloud tariff CX43

### DIFF
--- a/.github/workflows/ubuntu_build-template-for-22.04.yml
+++ b/.github/workflows/ubuntu_build-template-for-22.04.yml
@@ -16,6 +16,7 @@ on:
         required: true
         options:
           - cx33
+          - cx43
           - cpx22
           - ccx13  
         default: "cx33"


### PR DESCRIPTION
The storage space in the previous CX33 tariff is no longer sufficient for creating an image for Ubuntu 22.04. Therefore, the next larger tariff has been added.