### PR TITLE
Revert "[ubuntu] Update docker to 29.1.5, compose to 2.40.3"

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -222,11 +222,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "29.1.5"
+                "version": "28.0.4"
             },
             {
                 "package": "docker-ce",
-                "version": "29.1.5"
+                "version": "28.0.4"
             }
         ],
         "plugins": [
@@ -237,7 +237,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.40.3",
+                "version": "2.38.2",
                 "asset": "linux-x86_64"
             }
         ]

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -199,11 +199,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "29.1.5"
+                "version": "28.0.4"
             },
             {
                 "package": "docker-ce",
-                "version": "29.1.5"
+                "version": "28.0.4"
             }
         ],
         "plugins": [
@@ -214,7 +214,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.40.3",
+                "version": "2.38.2",
                 "asset": "linux-x86_64"
             }
         ]


### PR DESCRIPTION
# Description
This reverts commit [58fd81e](https://github.com/dwydler/runner-images-hetzner-cloud/commit/58fd81e995e62d107ba0c646dc7140e0ac0cdbd5).

#### Related issue:
## Check list
* [x]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [ ]  Changes are tested and related VM images are successfully generated