### PR TITLE
[Ubuntu] Update Maven to 3.9.13

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -73,7 +73,7 @@
     "java": {
         "default": "11",
         "versions": [ "8", "11", "17", "21", "25"],
-        "maven": "3.9.12"
+        "maven": "3.9.13"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -71,7 +71,7 @@
     "java": {
         "default": "17",
         "versions": [ "8", "11", "17", "21", "25"],
-        "maven": "3.9.12"
+        "maven": "3.9.13"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",


### PR DESCRIPTION
# Description
Maven version 3.9.12 is no longer available. Version 3.9.13 is the latest, available version. You can validate this through their cdn: https://dlcdn.apache.org/maven/maven-3/

Reference where the link is coming from:

https://github.com/actions/runner-images/blob/8f6f07be526a3a85eb066a862d81c242f0569802/images/ubuntu/scripts/build/install-java-tools.sh#L93

The image generation process is almost complete (ubuntu24), the java-tools part ran as expected. // Edit: It's complete.

#### Related issue:
#13771

## Check list
* [x]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [x]  Changes are tested and related VM images are successfully generated

