### PR TITLE
Fix GitHub repo sync name by using dynamic GitHub context

### DIFF
--- a/.github/workflows/manage_sync-fork-branch-main.yml
+++ b/.github/workflows/manage_sync-fork-branch-main.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           github_token: ${{ steps.generate-token.outputs.token }}
           upstream_repository: actions/runner-images
-          target_repository: dwydler/runner-images-hetzner-cloud
+          target_repository: ${{ github.repository }}
           upstream_branch: main
           target_branch: main
           force: false


### PR DESCRIPTION
This PR fixes the repository sync configuration by switching to a dynamic GitHub context for the target repository.

### 🔧 What Changed
- Updated workflow or configuration to derive the GitHub repository name dynamically instead of using a hardcoded value.
- Ensures that sync actions (e.g., repo sync workflows) correctly reference the current repository context.
- One file changed, aligning target repo references with the dynamic GitHub context.