### PR TITLE
Pin Super‑Linter GitHub Action to a specific commit

### DIFF
--- a/.github/workflows/tools_linter.yml
+++ b/.github/workflows/tools_linter.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter/slim@v7
+        uses: github/super-linter/slim@5cbf74118ff4db101cdcb76ce0b6387acb0d2a705f0ebdd24b01c78694696268  # v7.4.0
         env:
           VALIDATE_ALL_CODEBASE: false
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/tools_linter.yml
+++ b/.github/workflows/tools_linter.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter/slim@5cbf74118ff4db101cdcb76ce0b6387acb0d2a705f0ebdd24b01c78694696268  # v7.4.0
+        uses: github/super-linter/slim@12150456a73e248bdc94d0794898f94e23127c88  # v7.4.0
         env:
           VALIDATE_ALL_CODEBASE: false
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
This pull request updates the GitHub workflow(s) to pin the Super‑Linter action to a specific commit reference.

### 🔧 What Changed
- Replaced a generic or floating version tag (e.g., a tag like `@vX`) of the Super‑Linter action with an exact commit SHA.
- Ensures the linter action runs deterministically and avoids unintentional drift in behaviour due to tag updates. :contentReference[oaicite:1]{index=1}

### 🔒 Why
Pinning GitHub Actions to immutable references (such as a commit SHA) mitigates supply chain risks associated with unpinned or mutable tags, improving the security and stability of the workflows. :contentReference[oaicite:2]{index=2}

### 🧪 Notes
- There are no functional changes beyond the version pinning.
- Future updates to Super‑Linter should be handled explicitly by updating the pinned SHA.