### PR TITLE
Pin GitHub Actions to specific commit SHAs

### DIFF
--- a/.github/workflows/ubuntu_trigger-build-new-templates.yml
+++ b/.github/workflows/ubuntu_trigger-build-new-templates.yml
@@ -120,7 +120,7 @@ jobs:
           
           
       - name: Upload file software-report.json to artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@c6a366c94c3e0affe28c06c8df20a878f24da3cf  # v3.2.2
         with:
           name: software-report.json
           path: images/ubuntu/software-report.json
@@ -129,7 +129,7 @@ jobs:
           retention-days: 1
 
       - name: Upload file sbom.json.zip to artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@c6a366c94c3e0affe28c06c8df20a878f24da3cf  # v3.2.2
         with:
           name: sbom.json.zip
           path: images/ubuntu/sbom.json.zip
@@ -210,12 +210,12 @@ jobs:
           MERGE_READY_STATE: clean
 
       - name: Download file software-report.json from artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: software-report.json
 
       - name: Download file sbom.json.zip from artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: sbom.json.zip          
 

--- a/.github/workflows/ubuntu_trigger-cleanup-on-failure.yml
+++ b/.github/workflows/ubuntu_trigger-cleanup-on-failure.yml
@@ -28,7 +28,7 @@ jobs:
           private-key: ${{ secrets.GH_APP_RIHC_PRIVATE_KEY }}
           
       - name: Delete previously created branch
-        uses: dawidd6/action-delete-branch@v3
+        uses: dawidd6/action-delete-branch@d1efac9a6f7a9b408d4e8ff663a99c1fbac17b3f  # v3.1.0
         with:
           github_token: ${{ steps.generate-token.outputs.token }}
           branches: releases/${{ inputs.ReleaseTag }}


### PR DESCRIPTION
This PR updates GitHub Actions workflows by pinning all referenced actions to specific commit SHAs.

### 🔒 What Changed
- Replaced floating version tags (e.g., `@v1`, `@vX`) with exact commit SHA references across workflows.
- Standardized action versioning to ensure deterministic and reproducible CI runs.
- Applied consistent pinning strategy to all relevant GitHub Actions used in the repository.

### 🛡️ Why
Using mutable tags for GitHub Actions can introduce unintended changes or security risks if upstream actions are modified. Pinning to immutable commit SHAs improves:
- Supply chain security
- Workflow stability and reproducibility
- Auditability of CI/CD configurations

### ⚠️ Notes
- No functional changes are expected; this is a security and consistency improvement.
- Future updates to actions will require manually updating the pinned SHAs.