### PR TITLE
Fix GitHub Action variable names in workflows

### DIFF
--- a/.github/workflows/ubuntu_trigger-build-new-templates.yml
+++ b/.github/workflows/ubuntu_trigger-build-new-templates.yml
@@ -167,8 +167,8 @@ jobs:
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: generate-token
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.GH_APP_RIHC_ID }}
+          private-key: ${{ secrets.GH_APP_RIHC_PRIVATE_KEY }}
           
       - name: Checkout new created branch
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
This PR corrects variable names used in GitHub Actions workflows to ensure consistency and proper usage.

###  What Changed
- Fixed incorrect or mismatched environment variable names in one or more GitHub workflow files.
- Aligned variable names with expected inputs used by the actions.
- Cleaned up naming inconsistencies that could lead to workflow failures or confusion.