### PR TITLE
[ubuntu-24] Set read_ahead_kb kernel parameter to 128

### DIFF
--- a/images/ubuntu/scripts/build/configure-environment.sh
+++ b/images/ubuntu/scripts/build/configure-environment.sh
@@ -47,6 +47,16 @@ mkdir -p $rules_directory
 touch $netfilter_rule
 echo 'ACTION=="add", SUBSYSTEM=="module", KERNEL=="nf_conntrack", RUN+="/usr/sbin/sysctl net.netfilter.nf_conntrack_tcp_be_liberal=1"' | tee -a $netfilter_rule
 
+# https://github.com/actions/runner-images/issues/13770
+# https://github.com/ravendb/ravendb/discussions/22410
+# Linux kernel 6.17 changed read_ahead_kb default from 128 to 4096 on Azure VMs
+# where disks are presented as rotational (ROTA=1). This floods the page cache
+# with unused data during random-access I/O and causes memory exhaustion and thrashing.
+if is_ubuntu24; then
+    readahead_rule='/etc/udev/rules.d/99-readahead.rules'
+    echo 'ACTION=="add|change", KERNEL=="sd*", ATTR{queue/read_ahead_kb}="128"' | tee "$readahead_rule"
+fi
+
 # Create symlink for tests running
 chmod +x $HELPER_SCRIPTS/invoke-tests.sh
 ln -s $HELPER_SCRIPTS/invoke-tests.sh /usr/local/bin/invoke_tests

--- a/images/ubuntu/scripts/tests/System.Tests.ps1
+++ b/images/ubuntu/scripts/tests/System.Tests.ps1
@@ -22,3 +22,25 @@ Describe "fwupd removed" {
         $systemctlOutput | Should -Not -Match "active"
     }
 }
+
+# https://github.com/actions/runner-images/issues/13770
+# Linux kernel 6.17 changed read_ahead_kb from 128 to 4096 on Azure VMs, causing I/O thrashing
+Describe "ReadAhead udev rule" -Skip:(-not (Test-IsUbuntu24)) {
+    It "udev rule file exists" {
+        "/etc/udev/rules.d/99-readahead.rules" | Should -Exist
+    }
+
+    It "udev rule contains correct read_ahead_kb value" {
+        $content = Get-Content "/etc/udev/rules.d/99-readahead.rules" -Raw
+        $content | Should -Match 'ATTR\{queue/read_ahead_kb\}="128"'
+    }
+
+    It "All sd* devices have read_ahead_kb set to 128" {
+        $devices = Get-ChildItem "/sys/block/sd*/queue/read_ahead_kb" -ErrorAction SilentlyContinue
+        $devices | Should -Not -BeNullOrEmpty -Because "there should be at least one sd* block device"
+        foreach ($dev in $devices) {
+            $value = (Get-Content $dev.FullName).Trim()
+            $value | Should -Be "128" -Because "read_ahead_kb for $($dev.FullName) should be 128 to prevent I/O thrashing"
+        }
+    }
+}


### PR DESCRIPTION
Linux kernel 6.17 changed how read_ahead_kb is calculated based on disk properties. On Azure VMs, Standard SSD/HDD disks are presented as rotational (ROTA=1), which triggers scaling of read_ahead_kb from 128 to 4096.

This floods the page cache with unused data during random-access I/O, causing memory exhaustion and I/O thrashing. Affected workloads include C++ compilation, database operations, and other I/O-heavy tasks.

Add a udev rule to pin read_ahead_kb=128 for sd* block devices.

Refs: #13770 Refs: [ravendb/ravendb#22410](https://github.com/ravendb/ravendb/discussions/22410) Refs: [torvalds/linux@459779d04ae8](https://github.com/torvalds/linux/commit/459779d04ae8)

#### Related issue:
## Check list
* [x]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [x]  Changes are tested and related VM images are successfully generated
