### PR TITLE
[ubuntu-24] Preinstall 3 versions of awf for agentic workflow

### DIFF
--- a/images/ubuntu/scripts/build/install-awf.sh
+++ b/images/ubuntu/scripts/build/install-awf.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -e
+################################################################################
+##  File:  install-awf.sh
+##  Desc:  Install Agent Workflow Firewall JS bundle (most recent 3 versions)
+##  Supply chain security: AWF - checksum validation
+################################################################################
+
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/install.sh
+
+# Number of versions to install (current + 2 previous)
+NUM_VERSIONS=3
+
+# Get the most recent stable releases (exclude pre-releases, beta and release without assets)
+releases=$(curl -fsSL "https://api.github.com/repos/github/gh-aw-firewall/releases?per_page=10")
+versions=$(echo "$releases" | jq -r '[.[] | select(.assets | length > 0) | select(.prerelease == false) | select(.tag_name | test(".*-[a-z]|beta") | not)] | .[:'"$NUM_VERSIONS"'] | .[].tag_name')
+
+if [[ -z "$versions" ]]; then
+    echo "Error: Unable to find AWF releases."
+    exit 1
+fi
+
+for tag in $versions; do
+    version="${tag#v}"
+    echo "Installing AWF JS bundle version $version to toolcache..."
+
+    # Download the JS bundle
+    bundle_url="https://github.com/github/gh-aw-firewall/releases/download/${tag}/awf-bundle.js"
+    bundle_path=$(download_with_retry "$bundle_url")
+
+    # Supply chain security - AWF
+    checksums_url="https://github.com/github/gh-aw-firewall/releases/download/${tag}/checksums.txt"
+    external_hash=$(get_checksum_from_url "$checksums_url" "awf-bundle.js" "SHA256")
+    use_checksum_comparison "$bundle_path" "$external_hash"
+
+    # Install to toolcache
+    awf_toolcache_path="$AGENT_TOOLSDIRECTORY/agentic-workflow-firewall-js/$version/x64"
+    mkdir -p "$awf_toolcache_path"
+    cp "$bundle_path" "$awf_toolcache_path/awf-bundle.js"
+
+    # Mark installation complete
+    touch "$AGENT_TOOLSDIRECTORY/agentic-workflow-firewall-js/$version/x64.complete"
+done
+
+invoke_tests "Tools" "AWF"

--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -409,3 +409,22 @@ project(NinjaTest NONE)
         Remove-Item -Path "/tmp/ninjaproject" -Recurse -Force
     }
 }
+
+Describe "AWF" -Skip:(Test-IsUbuntu22) {
+    It "AWF toolcache directory exists" {
+        $awfPath = Join-Path $env:AGENT_TOOLSDIRECTORY "agentic-workflow-firewall-js"
+        $awfPath | Should -Exist
+    }
+
+    It "At least 3 versions are installed" {
+        $awfPath = Join-Path $env:AGENT_TOOLSDIRECTORY "agentic-workflow-firewall-js"
+        (Get-ChildItem -Path $awfPath -Directory).Count | Should -BeGreaterOrEqual 3
+    }
+
+    It "AWF JS bundle exists" {
+        $awfPath = Join-Path $env:AGENT_TOOLSDIRECTORY "agentic-workflow-firewall-js"
+        $latestVersion = Get-ChildItem -Path $awfPath -Directory | Sort-Object -Property { [version]$_.Name } -Descending | Select-Object -First 1
+        $bundlePath = Join-Path $latestVersion.FullName "x64" "awf-bundle.js"
+        $bundlePath | Should -Exist
+    }
+}

--- a/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
@@ -213,6 +213,7 @@ build {
       "${path.root}/../scripts/build/install-swift.sh",
       "${path.root}/../scripts/build/install-cmake.sh",
       "${path.root}/../scripts/build/install-codeql-bundle.sh",
+      "${path.root}/../scripts/build/install-awf.sh",
       "${path.root}/../scripts/build/install-container-tools.sh",
       "${path.root}/../scripts/build/install-dotnetcore-sdk.sh",
       "${path.root}/../scripts/build/install-microsoft-edge.sh",


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement? Please include a summary of the change and which issue is fixed. Also include relevant motivation and context. **For new tools, please provide total size and installation time.**

Following [ADR](https://github.com/github/c2c-actions/blob/main/docs/adrs/9990-reduce-aw-setup-time.md#4-pre-install-cli-binaries) to pre-install awf js bundle in runner images. 3 versions of awf bundle ~1MB.

#### Related issue: https://github.com/github/c2c-actions/issues/9991
## Check list
* [ ]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [ ]  Changes are tested and related VM images are successfully generated
