### PR TITLE
Fix remaining client-id usage in GitHub App token workflow

### DIFF
--- a/.github/workflows/ubuntu_trigger-build-new-templates.yml
+++ b/.github/workflows/ubuntu_trigger-build-new-templates.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: generate-token
         with:
-          app-id: ${{ secrets.GH_APP_RIHC_ID }}
+          client-id: ${{ secrets.GH_APP_RIHC_ID }}
           private-key: ${{ secrets.GH_APP_RIHC_PRIVATE_KEY }}
     
       - name: Create a new branch
@@ -72,7 +72,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: generate-token
         with:
-          app-id: ${{ secrets.GH_APP_RIHC_ID }}
+          client-id: ${{ secrets.GH_APP_RIHC_ID }}
           private-key: ${{ secrets.GH_APP_RIHC_PRIVATE_KEY }}
           
       - name: Checkout new created branch


### PR DESCRIPTION
This PR fixes GitHub App token generation by switching from app ID to client ID in the workflow configuration.

### What Changed
- Replaced usage of `app-id` with `client-id` in the GitHub Action configuration.
