### PR TITLE
Add Renovate bot via GitHub Actions for automated dependency updates

### DIFF
--- a/.github/workflows/tools_renovate.yml
+++ b/.github/workflows/tools_renovate.yml
@@ -1,0 +1,48 @@
+---
+name: Tools - Renovate
+
+"on":
+  schedule:
+    - cron: "0 6 * * *"  # jeden Tag um 06:00 Uhr
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        type: choice
+        required: false
+        options:
+          - info
+          - debug
+        default: "info"
+
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate app token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
+        id: generate-token
+        with:
+          client-id: ${{ secrets.GH_APP_RDP_ID }}
+          private-key: ${{ secrets.GH_APP_RDP_PRIVATE_KEY }}
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@f66d8679fcfcfa051abde6e7a623007173bf5164  # v46.1.12
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          # token: ${{ secrets.GH_TOKEN }}
+        env:
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
+          # Repository taken from variable to keep configuration file generic
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          # This flag will stop renovate from trying to create an onboarding PR, instead it will look for renovate.json file and run
+          RENOVATE_ONBOARDING: "false"
+          RENOVATE_DEPENDENCY_DASHBOARD_AUTOCLOSE: "true"
+          RENOVATE_DEPENDENCY_DASHBOARD_TITLE: "Renovate Dependency Dashboard"

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,41 @@
+renovate.json5
+
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'config:recommended',
+    'helpers:pinGitHubActionDigests',
+  ],
+  commitMessagePrefix: 'chore(deps):',
+  timezone: 'Europe/Berlin',
+  prHourlyLimit: 0,
+  prConcurrentLimit: 0,
+  automerge: false,
+  enabledManagers: [
+    'github-actions',
+  ],
+
+
+  packageRules: [
+    {
+      // ===========================================================================
+      // GitHub Actions
+      // ===========================================================================  
+      matchManagers: [
+        'github-actions',
+      ],
+      matchPackageNames: [
+        '*',
+      ],
+      labels: [
+        'dependencies',
+        'github_actions',
+      ],
+      draftPR: true,
+      additionalBranchPrefix: 'github_action/',
+      branchTopic: '{{depNameSanitized}}-{{#if newVersion}}{{newVersion}}{{else}}{{currentValue}}-{{newDigest}}{{/if}}',
+      commitMessageTopic: '{{depName}}',
+      commitMessageExtra: '{{#if newVersion}}from {{currentVersion}} to {{newVersion}}{{else}}{{newValue}} from {{currentDigestShort}} to {{newDigestShort}}{{/if}}',
+    },
+  ],
+}


### PR DESCRIPTION
This PR adds Renovate bot integration using a GitHub Actions workflow to automate dependency updates.

### What Changed
- Added a GitHub Actions workflow to run Renovate.
- Introduced Renovate configuration for dependency management.
- Enabled automated updates for dependencies such as:
  - GitHub Actions
