### PR TITLE
[ubuntu] Add Ubuntu-26.04 image generation code

### DIFF
--- a/images/ubuntu/scripts/build/configure-apt-sources.sh
+++ b/images/ubuntu/scripts/build/configure-apt-sources.sh
@@ -12,7 +12,7 @@ printf "http://azure.archive.ubuntu.com/ubuntu/\tpriority:1\n" | tee -a /etc/apt
 printf "https://archive.ubuntu.com/ubuntu/\tpriority:2\n" | tee -a /etc/apt/apt-mirrors.txt
 printf "https://security.ubuntu.com/ubuntu/\tpriority:3\n" | tee -a /etc/apt/apt-mirrors.txt
 
-if is_ubuntu24; then
+if ! is_ubuntu22; then
     sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu/|mirror+file:/etc/apt/apt-mirrors.txt|' /etc/apt/sources.list.d/ubuntu.sources
 
     # Apt changes to survive Cloud Init

--- a/images/ubuntu/scripts/build/configure-apt.sh
+++ b/images/ubuntu/scripts/build/configure-apt.sh
@@ -40,7 +40,7 @@ EOF
 apt-get purge unattended-upgrades
 
 echo 'APT sources'
-if ! is_ubuntu24; then
+if is_ubuntu22; then
     cat /etc/apt/sources.list
 else
     cat /etc/apt/sources.list.d/ubuntu.sources
@@ -51,7 +51,7 @@ apt-get upgrade -y
 # Install jq
 apt-get install jq
 
-if ! is_ubuntu24; then
+if is_ubuntu22; then
     # Install apt-fast using quick-install.sh
     # https://github.com/ilikenwf/apt-fast
     bash -c "$(curl -fsSL https://raw.githubusercontent.com/ilikenwf/apt-fast/master/quick-install.sh)"

--- a/images/ubuntu/scripts/build/configure-environment.sh
+++ b/images/ubuntu/scripts/build/configure-environment.sh
@@ -52,7 +52,7 @@ echo 'ACTION=="add", SUBSYSTEM=="module", KERNEL=="nf_conntrack", RUN+="/usr/sbi
 # Linux kernel 6.17 changed read_ahead_kb default from 128 to 4096 on Azure VMs
 # where disks are presented as rotational (ROTA=1). This floods the page cache
 # with unused data during random-access I/O and causes memory exhaustion and thrashing.
-if is_ubuntu24; then
+if ! is_ubuntu22; then
     readahead_rule='/etc/udev/rules.d/99-readahead.rules'
     echo 'ACTION=="add|change", KERNEL=="sd*", ATTR{queue/read_ahead_kb}="128"' | tee "$readahead_rule"
 fi

--- a/images/ubuntu/scripts/build/install-cmake.sh
+++ b/images/ubuntu/scripts/build/install-cmake.sh
@@ -8,17 +8,19 @@
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/install.sh
 
+cmake_version=$(get_toolset_value .cmake.version)
+
 # Test to see if the software in question is already installed, if not install it
 echo "Checking to see if the installer script has already been run"
 if command -v cmake; then
     echo "cmake is already installed"
 else
 	# Download script to install CMake
-	download_url=$(resolve_github_release_asset_url "Kitware/CMake" "endswith(\"inux-x86_64.sh\")" "3.31.6")
+	download_url=$(resolve_github_release_asset_url "Kitware/CMake" "endswith(\"inux-x86_64.sh\")" "$cmake_version")
 	curl -fsSL "${download_url}" -o cmakeinstall.sh
 
 	# Supply chain security - CMake
-	hash_url=$(resolve_github_release_asset_url "Kitware/CMake" "endswith(\"SHA-256.txt\")" "3.31.6")
+	hash_url=$(resolve_github_release_asset_url "Kitware/CMake" "endswith(\"SHA-256.txt\")" "$cmake_version")
 	external_hash=$(get_checksum_from_url "$hash_url" "linux-x86_64.sh" "SHA256")
 	use_checksum_comparison "cmakeinstall.sh" "$external_hash"
 

--- a/images/ubuntu/scripts/build/install-dotnetcore-sdk.sh
+++ b/images/ubuntu/scripts/build/install-dotnetcore-sdk.sh
@@ -36,6 +36,10 @@ if is_ubuntu24; then
     apt-get install --no-install-recommends libicu74
 fi
 
+if is_ubuntu26; then
+    apt-get install --no-install-recommends libicu78
+fi
+
 # Install .NET SDKs and Runtimes
 mkdir -p /usr/share/dotnet
 

--- a/images/ubuntu/scripts/build/install-firefox.sh
+++ b/images/ubuntu/scripts/build/install-firefox.sh
@@ -8,24 +8,18 @@
 source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/etc-environment.sh
 
-# Mozillateam PPA is added manually because sometimes
-# launchpad portal sends empty answer when trying to add it automatically
-
-REPO_URL="https://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu/"
-GPG_FINGERPRINT="0ab215679c571d1c8325275b9bdb3d89ce49ec21"
-GPG_KEY="/etc/apt/trusted.gpg.d/mozillateam_ubuntu_ppa.gpg"
-REPO_PATH="/etc/apt/sources.list.d/mozillateam-ubuntu-ppa-focal.list"
+FIREFOX_REPO="ppa:mozillateam/ppa"
 
 # Install Firefox
-curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x${GPG_FINGERPRINT}" | sudo gpg --dearmor -o $GPG_KEY
-echo "deb $REPO_URL $(lsb_release -cs) main" > $REPO_PATH
-
+add-apt-repository $FIREFOX_REPO -y
 apt-get update
-apt-get install --target-release 'o=LP-PPA-mozillateam' firefox
-rm $REPO_PATH
+apt-get install --target-release 'o=LP-PPA-mozillateam' -y firefox
+
+# Remove source repo's
+add-apt-repository --remove $FIREFOX_REPO
 
 # Document apt source repo's
-echo "mozillateam $REPO_URL" >> $HELPER_SCRIPTS/apt-sources.txt
+echo "mozillateam $FIREFOX_REPO" >> $HELPER_SCRIPTS/apt-sources.txt
 
 # add to global system preferences for firefox locale en_US, because other browsers have en_US local.
 # Default firefox local is en_GB

--- a/images/ubuntu/scripts/build/install-java-tools.sh
+++ b/images/ubuntu/scripts/build/install-java-tools.sh
@@ -64,12 +64,16 @@ install_open_jdk() {
 # Add Adoptium PPA
 # apt-key is deprecated, dearmor and add manually
 wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor > /usr/share/keyrings/adoptium.gpg
-echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/adoptium.list
+# Adoptium doesn't have packages for Ubuntu 26.04 (resolute) yet, use noble as a fallback
+adoptium_codename=$(lsb_release -cs)
+if [[ "${adoptium_codename}" == "resolute" ]]; then
+    adoptium_codename="noble"
+fi
+echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb/ ${adoptium_codename} main" > /etc/apt/sources.list.d/adoptium.list
 
 # Get all the updates from enabled repositories.
 apt-get update
 
-# While Ubuntu 24.04 binaries are not released in the Adoptium repo, we will not install Java
 defaultVersion=$(get_toolset_value '.java.default')
 jdkVersionsToInstall=($(get_toolset_value ".java.versions[]"))
 

--- a/images/ubuntu/scripts/build/install-php.sh
+++ b/images/ubuntu/scripts/build/install-php.sh
@@ -32,7 +32,6 @@ for version in $php_versions; do
         php$version-gmp \
         php$version-igbinary \
         php$version-imagick \
-        php$version-imap \
         php$version-interbase \
         php$version-intl \
         php$version-ldap \
@@ -42,7 +41,6 @@ for version in $php_versions; do
         php$version-mongodb \
         php$version-mysql \
         php$version-odbc \
-        php$version-opcache \
         php$version-pgsql \
         php$version-phpdbg \
         php$version-pspell \
@@ -60,6 +58,14 @@ for version in $php_versions; do
         php$version-zip \
         php$version-zmq
 
+        # https://php.watch/versions/8.4/imap-unbundled
+        # https://php.watch/articles/php-8-5-installation-upgrade-guide-debian-ubuntu
+        if [[ $version == "8.1" || $version == "8.3" ]]; then
+            apt-get install --no-install-recommends \
+                php$version-imap \
+                php$version-opcache
+        fi
+
         apt-get install --no-install-recommends php$version-pcov
 
         # Disable PCOV, as Xdebug is enabled by default
@@ -70,7 +76,7 @@ for version in $php_versions; do
         apt-get install --no-install-recommends php$version-recode
     fi
 
-    if [[ $version != "8.0" && $version != "8.1" && $version != "8.2" && $version != "8.3" ]]; then
+    if [[ $version != "8.0" && $version != "8.1" && $version != "8.2" && $version != "8.3" && $version != "8.5" ]]; then
         apt-get install --no-install-recommends php$version-xmlrpc php$version-json
     fi
 done

--- a/images/ubuntu/scripts/build/install-powershell.sh
+++ b/images/ubuntu/scripts/build/install-powershell.sh
@@ -10,6 +10,24 @@ source $HELPER_SCRIPTS/os.sh
 
 pwsh_version=$(get_toolset_value .pwsh.version)
 
-# Install Powershell
+if is_ubuntu26; then
+    # pwsh for ubuntu 26.04 is not yet available in apt repo, install from GitHub release tarball
+    # Ubuntu 26.04: install from GitHub release tarball
+    download_url=$(resolve_github_release_asset_url "PowerShell/PowerShell" "endswith(\"linux-x64.tar.gz\")" "$pwsh_version" "" "true")
+    archive_path=$(download_with_retry "$download_url")
 
+    # Create the target folder where powershell will be placed
+    sudo mkdir -p /opt/microsoft/powershell/7
+
+    # Expand powershell to the target folder
+    sudo tar zxf "$archive_path" -C /opt/microsoft/powershell/7
+
+    # Set execute permissions
+    sudo chmod +x /opt/microsoft/powershell/7/pwsh
+
+    # Create the symbolic link that points to pwsh
+    sudo ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+else
+    # Install Powershell via apt
     apt-get install powershell=$pwsh_version*
+fi

--- a/images/ubuntu/scripts/build/install-python.sh
+++ b/images/ubuntu/scripts/build/install-python.sh
@@ -12,8 +12,8 @@ source $HELPER_SCRIPTS/os.sh
 # Install Python, Python 3, pip, pip3
 apt-get install --no-install-recommends python3 python3-dev python3-pip python3-venv
 
-if is_ubuntu24; then
-# Create temporary workaround to allow user to continue using pip
+if ! is_ubuntu22; then
+# allow user to continue using pip
     sudo cat <<EOF > /etc/pip.conf
 [global]
 break-system-packages = true

--- a/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -45,7 +45,7 @@ $languageAndRuntime.AddToolVersionsListInline("GNU C++", $(Get-CPPVersions), "^\
 $languageAndRuntime.AddToolVersionsListInline("GNU Fortran", $(Get-FortranVersions), "^\d+")
 $languageAndRuntime.AddToolVersion("Julia", $(Get-JuliaVersion))
 $languageAndRuntime.AddToolVersion("Kotlin", $(Get-KotlinVersion))
-if (-not $(Test-IsUbuntu24)) {
+if (Test-IsUbuntu22) {
     $languageAndRuntime.AddToolVersion("Mono", $(Get-MonoVersion))
     $languageAndRuntime.AddToolVersion("MSBuild", $(Get-MsbuildVersion))
 }
@@ -53,7 +53,10 @@ $languageAndRuntime.AddToolVersion("Node.js", $(Get-NodeVersion))
 $languageAndRuntime.AddToolVersion("Perl", $(Get-PerlVersion))
 $languageAndRuntime.AddToolVersion("Python", $(Get-PythonVersion))
 $languageAndRuntime.AddToolVersion("Ruby", $(Get-RubyVersion))
-$languageAndRuntime.AddToolVersion("Swift", $(Get-SwiftVersion))
+if (-not (Test-IsUbuntu26)) {
+    # No Ubuntu 26 support yet
+    $languageAndRuntime.AddToolVersion("Swift", $(Get-SwiftVersion))
+}
 
 
 # Package Management
@@ -63,7 +66,7 @@ $packageManagement.AddToolVersion("Helm", $(Get-HelmVersion))
 $packageManagement.AddToolVersion("Homebrew", $(Get-HomebrewVersion))
 $packageManagement.AddToolVersion("Miniconda", $(Get-MinicondaVersion))
 $packageManagement.AddToolVersion("Npm", $(Get-NpmVersion))
-if (-not $(Test-IsUbuntu24)) {
+if (Test-IsUbuntu22) {
     $packageManagement.AddToolVersion("NuGet", $(Get-NuGetVersion))
 }
 $packageManagement.AddToolVersion("Pip", $(Get-PipVersion))
@@ -229,18 +232,20 @@ $databasesTools = $installedSoftware.AddHeader("Databases")
 $databasesTools.AddToolVersion("sqlite3", $(Get-SqliteVersion))
 $databasesTools.AddNode($(Build-PostgreSqlSection))
 $databasesTools.AddNode($(Build-MySQLSection))
-if (-not $(Test-IsUbuntu24)) {
+if (Test-IsUbuntu22) {
     $databasesTools.AddNode($(Build-MSSQLToolsSection))
 }
 
 # Cached Tools
-$cachedTools = $installedSoftware.AddHeader("Cached Tools")
-$cachedTools.AddToolVersionsList("Go", $(Get-ToolcacheGoVersions), "^\d+\.\d+")
-$cachedTools.AddToolVersionsList("Node.js", $(Get-ToolcacheNodeVersions), "^\d+")
-$cachedTools.AddToolVersionsList("Python", $(Get-ToolcachePythonVersions), "^\d+\.\d+")
-$cachedTools.AddToolVersionsList("PyPy", $(Get-ToolcachePyPyVersions), "^\d+\.\d+")
-$cachedTools.AddToolVersionsList("Ruby", $(Get-ToolcacheRubyVersions), "^\d+\.\d+")
-
+if (-not(Test-IsUbuntu26)) {
+    # Most cached tools are not yet available for Ubuntu 26.04
+    $cachedTools = $installedSoftware.AddHeader("Cached Tools")
+    $cachedTools.AddToolVersionsList("Go", $(Get-ToolcacheGoVersions), "^\d+\.\d+")
+    $cachedTools.AddToolVersionsList("Node.js", $(Get-ToolcacheNodeVersions), "^\d+")
+    $cachedTools.AddToolVersionsList("Python", $(Get-ToolcachePythonVersions), "^\d+\.\d+")
+    $cachedTools.AddToolVersionsList("PyPy", $(Get-ToolcachePyPyVersions), "^\d+\.\d+")
+    $cachedTools.AddToolVersionsList("Ruby", $(Get-ToolcacheRubyVersions), "^\d+\.\d+")
+}
 
 # PowerShell Tools
 $powerShellTools = $installedSoftware.AddHeader("PowerShell Tools")

--- a/images/ubuntu/scripts/helpers/Common.Helpers.psm1
+++ b/images/ubuntu/scripts/helpers/Common.Helpers.psm1
@@ -62,6 +62,10 @@ function Test-IsUbuntu24 {
     return (lsb_release -rs) -eq "24.04"
 }
 
+function Test-IsUbuntu26 {
+    return (lsb_release -rs) -eq "26.04"
+}
+
 function Get-ToolsetContent {
     <#
     .SYNOPSIS

--- a/images/ubuntu/scripts/helpers/os.sh
+++ b/images/ubuntu/scripts/helpers/os.sh
@@ -11,3 +11,7 @@ is_ubuntu22() {
 is_ubuntu24() {
     lsb_release -rs | grep -q '24.04'
 }
+
+is_ubuntu26() {
+    lsb_release -rs | grep -q '26.04'
+}

--- a/images/ubuntu/scripts/tests/Apt.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Apt.Tests.ps1
@@ -10,6 +10,7 @@ Describe "Apt" {
             "aria2"             { $toolName = "aria2c"; break }
             "libnss3-tools"     { $toolName = "certutil"; break }
             "p7zip-full"        { $toolName = "p7zip"; break }
+            "7zip"              { $toolName = "7z"; break }
             "subversion"        { $toolName = "svn"; break }
             "sphinxsearch"      { $toolName = "searchd"; break }
             "binutils"          { $toolName = "strings"; break }

--- a/images/ubuntu/scripts/tests/Common.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Common.Tests.ps1
@@ -24,7 +24,7 @@ Describe "PHP" {
     }
 }
 
-Describe "Swift" {
+Describe "Swift" -Skip:(Test-IsUbuntu26) {
     It "swift" {
         "swift --version" | Should -ReturnZeroExitCode
     }

--- a/images/ubuntu/scripts/tests/System.Tests.ps1
+++ b/images/ubuntu/scripts/tests/System.Tests.ps1
@@ -25,7 +25,7 @@ Describe "fwupd removed" {
 
 # https://github.com/actions/runner-images/issues/13770
 # Linux kernel 6.17 changed read_ahead_kb from 128 to 4096 on Azure VMs, causing I/O thrashing
-Describe "ReadAhead udev rule" -Skip:(-not (Test-IsUbuntu24)) {
+Describe "ReadAhead udev rule" -Skip:(Test-IsUbuntu22) {
     It "udev rule file exists" {
         "/etc/udev/rules.d/99-readahead.rules" | Should -Exist
     }

--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -162,7 +162,7 @@ Describe "gfortran" {
     }
 }
 
-Describe "Mono" -Skip:(Test-IsUbuntu24) {
+Describe "Mono" -Skip:((-not (Test-IsUbuntu22))) {
     It "mono" {
         "mono --version" | Should -ReturnZeroExitCode
     }

--- a/images/ubuntu/templates/build.ubuntu-26.04.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-26.04.pkr.hcl
@@ -1,0 +1,256 @@
+build {
+  sources = ["source.hcloud.ubuntu-base-image"]
+  name = "ubuntu-26.04"
+
+  provisioner "shell" {
+    inline           = ["cloud-init status --wait --long"]
+    valid_exit_codes = [0, 2]
+  }
+
+  provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    inline          = ["mkdir ${var.image_folder}", "chmod 777 ${var.image_folder}"]
+  }
+
+  provisioner "file" {
+    destination = "${var.helper_script_folder}"
+    source      = "${path.root}/../scripts/helpers"
+  }
+
+  provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    script          = "${path.root}/../scripts/build/configure-apt-mock.sh"
+  }
+
+  provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}","DEBIAN_FRONTEND=noninteractive"]
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = [
+      "${path.root}/../scripts/build/install-ms-repos.sh",
+      "${path.root}/../scripts/build/configure-apt-sources.sh",
+      "${path.root}/../scripts/build/configure-apt.sh"
+    ]
+  }
+
+  provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    script          = "${path.root}/../scripts/build/configure-limits.sh"
+  }
+
+  provisioner "file" {
+    destination = "${var.installer_script_folder}"
+    source      = "${path.root}/../scripts/build"
+  }
+
+  provisioner "file" {
+    destination = "${var.image_folder}"
+    sources     = [
+      "${path.root}/../assets/post-gen",
+      "${path.root}/../scripts/tests",
+      "${path.root}/../scripts/docs-gen"
+    ]
+  }
+
+  provisioner "file" {
+    destination = "${var.image_folder}/docs-gen/"
+    source      = "${path.root}/../../../helpers/software-report-base"
+  }
+
+  provisioner "file" {
+    destination = "${var.installer_script_folder}/toolset.json"
+    source      = "${path.root}/../toolsets/toolset-2604.json"
+  }
+
+  provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    inline          = [
+      "mv ${var.image_folder}/docs-gen ${var.image_folder}/SoftwareReport",
+      "mv ${var.image_folder}/post-gen ${var.image_folder}/post-generation"
+    ]
+  }
+
+  provisioner "shell" {
+    environment_vars = ["IMAGE_VERSION=${var.image_version}", "IMAGEDATA_FILE=${var.imagedata_file}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/configure-image-data.sh"]
+  }
+
+  provisioner "shell" {
+    environment_vars = ["IMAGE_VERSION=${var.image_version}", "IMAGE_OS=${var.os_image_name}", "HELPER_SCRIPTS=${var.helper_script_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/configure-environment.sh"]
+  }
+
+  provisioner "shell" {
+    environment_vars = ["DEBIAN_FRONTEND=noninteractive", "HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/install-apt-vital.sh"]
+  }
+
+  provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/install-powershell.sh"]
+  }
+
+  provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/Install-PowerShellModules.ps1", "${path.root}/../scripts/build/Install-PowerShellAzModules.ps1"]
+  }
+
+  provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}", "DEBIAN_FRONTEND=noninteractive"]
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = [
+      "${path.root}/../scripts/build/install-actions-cache.sh",
+      "${path.root}/../scripts/build/install-apt-common.sh",
+      "${path.root}/../scripts/build/install-azcopy.sh",
+      "${path.root}/../scripts/build/install-azure-cli.sh",
+      "${path.root}/../scripts/build/install-azure-devops-cli.sh",
+      "${path.root}/../scripts/build/install-bicep.sh",
+      "${path.root}/../scripts/build/install-apache.sh",
+      "${path.root}/../scripts/build/install-aws-tools.sh",
+      "${path.root}/../scripts/build/install-clang.sh",
+      "${path.root}/../scripts/build/install-cmake.sh",
+      "${path.root}/../scripts/build/install-codeql-bundle.sh",
+      "${path.root}/../scripts/build/install-awf.sh",
+      "${path.root}/../scripts/build/install-container-tools.sh",
+      "${path.root}/../scripts/build/install-dotnetcore-sdk.sh",
+      "${path.root}/../scripts/build/install-microsoft-edge.sh",
+      "${path.root}/../scripts/build/install-gcc-compilers.sh",
+      "${path.root}/../scripts/build/install-firefox.sh",
+      "${path.root}/../scripts/build/install-gfortran.sh",
+      "${path.root}/../scripts/build/install-git.sh",
+      "${path.root}/../scripts/build/install-git-lfs.sh",
+      "${path.root}/../scripts/build/install-github-cli.sh",
+      "${path.root}/../scripts/build/install-google-chrome.sh",
+      "${path.root}/../scripts/build/install-google-cloud-cli.sh",
+      "${path.root}/../scripts/build/install-haskell.sh",
+      "${path.root}/../scripts/build/install-java-tools.sh",
+      "${path.root}/../scripts/build/install-kubernetes-tools.sh",
+      "${path.root}/../scripts/build/install-miniconda.sh",
+      "${path.root}/../scripts/build/install-kotlin.sh",
+      "${path.root}/../scripts/build/install-mysql.sh",
+      "${path.root}/../scripts/build/install-nginx.sh",
+      "${path.root}/../scripts/build/install-nvm.sh",
+      "${path.root}/../scripts/build/install-nodejs.sh",
+      "${path.root}/../scripts/build/install-bazel.sh",
+      "${path.root}/../scripts/build/install-php.sh",
+      "${path.root}/../scripts/build/install-postgresql.sh",
+      "${path.root}/../scripts/build/install-pulumi.sh",
+      "${path.root}/../scripts/build/install-ruby.sh",
+      "${path.root}/../scripts/build/install-rust.sh",
+      "${path.root}/../scripts/build/install-julia.sh",
+      "${path.root}/../scripts/build/install-selenium.sh",
+      "${path.root}/../scripts/build/install-packer.sh",
+      "${path.root}/../scripts/build/install-vcpkg.sh",
+      "${path.root}/../scripts/build/configure-dpkg.sh",
+      "${path.root}/../scripts/build/install-yq.sh",
+      "${path.root}/../scripts/build/install-android-sdk.sh",
+      "${path.root}/../scripts/build/install-pypy.sh",
+      "${path.root}/../scripts/build/install-python.sh",
+      "${path.root}/../scripts/build/install-zstd.sh",
+      "${path.root}/../scripts/build/install-ninja.sh"
+    ]
+  }
+
+  provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/install-docker.sh"]
+  }
+
+  provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} pwsh -f {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/Install-Toolset.ps1", "${path.root}/../scripts/build/Configure-Toolset.ps1"]
+  }
+
+  provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/install-pipx-packages.sh"]
+  }
+
+  provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "DEBIAN_FRONTEND=noninteractive", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+    execute_command  = "/bin/sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/install-homebrew.sh"]
+  }
+
+  provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/configure-snap.sh"]
+  }
+
+  provisioner "shell" {
+    execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    script          = "${path.root}/../scripts/build/list-dpkg.sh"
+  }
+
+  provisioner "shell" {
+    execute_command   = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    expect_disconnect = true
+    inline            = ["echo 'Reboot VM'", "sudo reboot"]
+  }
+
+  provisioner "shell" {
+    execute_command     = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    pause_before        = "5m0s"
+    scripts             = ["${path.root}/../scripts/build/cleanup.sh"]
+    start_retry_timeout = "10m"
+  }
+
+  provisioner "shell" {
+    environment_vars = ["IMAGE_VERSION=${var.image_version}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+    inline           = ["pwsh -File ${var.image_folder}/SoftwareReport/Generate-SoftwareReport.ps1 -OutputDirectory ${var.image_folder}", "pwsh -File ${var.image_folder}/tests/RunAll-Tests.ps1 -OutputDirectory ${var.image_folder}"]
+  }
+
+  provisioner "shell" {
+    environment_vars = ["IMAGE_VERSION=${var.image_version}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}"]
+    inline           = ["sudo sh ${var.image_folder}/SoftwareReport/Generate-SBOM.sh ${var.image_folder}"]
+  }
+
+  provisioner "file" {
+    destination = "${path.root}/../Ubuntu2604-Readme.md"
+    direction   = "download"
+    source      = "${var.image_folder}/software-report.md"
+  }
+
+  provisioner "file" {
+    destination = "${path.root}/../software-report.json"
+    direction   = "download"
+    source      = "${var.image_folder}/software-report.json"
+  }
+
+  provisioner "file" {
+    destination = "${path.root}/../sbom.json.zip"
+    direction   = "download"
+    source      = "${var.image_folder}/sbom.json.zip"
+  }
+
+  provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPT_FOLDER=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}", "IMAGE_FOLDER=${var.image_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/configure-system.sh"]
+  }
+
+  provisioner "shell" {
+    environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}"]
+    execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+    scripts          = ["${path.root}/../scripts/build/post-build-validation.sh"]
+  }
+
+  provisioner "shell" {
+    inline           = ["cloud-init clean --machine-id --seed --logs", "rm -rf /run/cloud-init/\\*", "rm -rf /var/lib/cloud/\\*"]
+    valid_exit_codes = [0, 2]
+  }
+
+  provisioner "shell" {
+    inline           = ["dd if=/dev/zero of=/zero bs=4M || true", "sync", "rm -f /zero"]
+    valid_exit_codes = [0]
+  }
+
+}

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -320,6 +320,9 @@
     "postgresql": {
         "version": "16"
     },
+    "cmake": {
+        "version": "3.31.6"
+    },
     "pwsh": {
         "version": "7.4"
     }

--- a/images/ubuntu/toolsets/toolset-2604.json
+++ b/images/ubuntu/toolsets/toolset-2604.json
@@ -4,14 +4,9 @@
             "name": "Python",
             "url" : "https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json",
             "platform" : "linux",
-            "platform_version": "22.04",
+            "platform_version": "26.04",
             "arch": "x64",
             "versions": [
-                "3.10.*",
-                "3.11.*",
-                "3.12.*",
-                "3.13.*",
-                "3.14.*"
             ]
         },
         {
@@ -19,8 +14,6 @@
             "arch": "x64",
             "platform" : "linux",
             "versions": [
-                "3.7",
-                "3.8",
                 "3.9",
                 "3.10",
                 "3.11"
@@ -43,22 +36,17 @@
             "arch": "x64",
             "platform" : "linux",
             "versions": [
-                "1.22.*",
-                "1.23.*",
                 "1.24.*",
-                "1.25.*"
+                "1.25.*",
+                "1.26.*"
             ],
-            "default": "1.24.*"
+            "default": "1.26.*"
         },
         {
             "name": "Ruby",
-            "platform_version": "22.04",
+            "platform_version": "26.04",
             "arch": "x64",
             "versions": [
-                "3.2.*",
-                "3.3.*",
-                "3.4.*",
-                "4.0.*"
             ]
         },
         {
@@ -71,12 +59,12 @@
         }
     ],
     "java": {
-        "default": "11",
-        "versions": [ "8", "11", "17", "21", "25"],
-        "maven": "3.9"
+        "default": "21",
+        "versions": [ "11", "17", "21", "25" ],
+        "maven": "3.9.15"
     },
     "android": {
-        "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",
+        "cmdline-tools": "commandlinetools-linux-14742923_latest.zip",
         "platform_min_version": "34",
         "build_tools_min_version": "34.0.0",
         "extra_list": [
@@ -87,9 +75,8 @@
         "addon_list": [
         ],
         "additional_tools": [
-            "cmake;3.18.1",
-            "cmake;3.22.1",
-            "cmake;3.31.5"
+            "cmake;3.31.5",
+            "cmake;4.1.2"
         ],
         "ndk": {
             "default": "27",
@@ -99,7 +86,6 @@
         }
     },
     "powershellModules": [
-        {"name": "MarkdownPS"},
         {"name": "Microsoft.Graph"},
         {"name": "Pester"},
         {"name": "PSScriptAnalyzer"}
@@ -108,7 +94,7 @@
         {
             "name": "az",
             "versions": [
-                "14.6.0"
+                "15.5.0"
             ]
         }
     ],
@@ -128,47 +114,30 @@
             "autoconf",
             "automake",
             "dbus",
-            "dnsutils",
+            "bind9-dnsutils",
             "dpkg",
             "dpkg-dev",
             "fakeroot",
             "fonts-noto-color-emoji",
             "gnupg2",
-            "imagemagick",
             "iproute2",
             "iputils-ping",
-            "lib32z1",
-            "libc++abi-dev",
-            "libc++-dev",
-            "libc6-dev",
-            "libcurl4",
-            "libgbm-dev",
-            "libgconf-2-4",
-            "libgsl-dev",
-            "libgtk-3-0",
-            "libmagic-dev",
-            "libmagickcore-dev",
-            "libmagickwand-dev",
-            "libsecret-1-dev",
-            "libsqlite3-dev",
             "libyaml-dev",
             "libtool",
-            "libunwind8",
-            "libxkbfile-dev",
-            "libxss1",
             "libssl-dev",
+            "libsqlite3-dev",
             "locales",
             "mercurial",
             "openssh-client",
-            "p7zip-rar",
+            "7zip-rar",
             "pkg-config",
             "python-is-python3",
             "rpm",
             "texinfo",
             "tk",
+            "tree",
             "tzdata",
             "upx",
-            "xorriso",
             "xvfb",
             "xz-utils",
             "zsync"
@@ -191,9 +160,8 @@
             "mediainfo",
             "netcat",
             "net-tools",
-            "p7zip-full",
+            "7zip",
             "parallel",
-            "pass",
             "patchelf",
             "pigz",
             "pollinate",
@@ -203,7 +171,6 @@
             "sqlite3",
             "ssh",
             "sshpass",
-            "subversion",
             "sudo",
             "systemd-coredump",
             "swig",
@@ -222,11 +189,11 @@
             },
             {
                 "package": "docker-ce-cli",
-                "version": "28.0.4"
+                "version": "29.4.2"
             },
             {
                 "package": "docker-ce",
-                "version": "28.0.4"
+                "version": "29.4.2"
             }
         ],
         "plugins": [
@@ -237,7 +204,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.38.2",
+                "version": "2.40.3",
                 "asset": "linux-x86_64"
             }
         ]
@@ -264,28 +231,29 @@
     },
     "clang": {
         "versions": [
-            "13",
-            "14",
-            "15"
+            "20",
+            "21",
+            "22"
         ],
-        "default_version": "14"
+        "default_version": "21"
     },
     "gcc": {
         "versions": [
-            "g++-10",
-            "g++-12"
+            "g++-13",
+            "g++-14",
+            "g++-15"
         ]
     },
     "gfortran": {
         "versions": [
-            "gfortran-9",
-            "gfortran-10",
-            "gfortran-12"
+            "gfortran-13",
+            "gfortran-14",
+            "gfortran-15"
         ]
     },
     "php": {
         "versions": [
-            "8.1"
+            "8.5"
         ]
     },
     "rubygems": [
@@ -295,7 +263,7 @@
         "version": "4"
     },
     "node": {
-        "default": "20"
+        "default": "24"
     },
     "node_modules": [
         {
@@ -323,20 +291,12 @@
             "command": "newman"
         },
         {
-            "name": "vercel",
-            "command": "vercel"
-        },
-        {
             "name": "webpack",
             "command": "webpack"
         },
         {
             "name": "webpack-cli",
             "command": "webpack-cli"
-        },
-        {
-            "name": "netlify-cli",
-            "command": "netlify"
         },
         {
             "name": "lerna",
@@ -347,13 +307,13 @@
             "command": "yarn"
         }
     ],
-     "postgresql": {
-        "version": "14"
+    "postgresql": {
+        "version": "18"
     },
     "cmake": {
-        "version": "3.31.6"
+        "version": "latest"
     },
     "pwsh": {
-        "version": "7.4"
+        "version": "7.6"
     }
 }


### PR DESCRIPTION
# Description
This PR adds Ubuntu 26.04 image generation code. Major tools will be updated to newer versions

Note

Currently there are following constraints, which will be changed later

* adoptium `java` is not yet available for `resolute`, install from `noble` instead
* `python` and `ruby` don't yet have 26.04 assets, toolcache configuration partially skipped
* `swift` is not yet available for ubuntu 26.04, skipped
* `pwsh` is not yet available in MS packages, installed from `PowerShell/PowerShell` release assets instead

#### Related issue: https://github.com/github/hosted-runners-images/issues/693, https://github.com/github/hosted-runners/issues/1796
## Check list
* [x]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [x]  Changes are tested and related VM images are successfully generated