### PR TITLE
[all OSs] Filter out toolcache pre-release versions

### DIFF
--- a/images/ubuntu/scripts/build/Install-Toolset.ps1
+++ b/images/ubuntu/scripts/build/Install-Toolset.ps1
@@ -35,6 +35,9 @@ foreach ($tool in $tools) {
     # Get versions manifest for current tool
     $assets = Invoke-RestMethod $tool.url
 
+    # Filter out pre-release versions
+    $assets = $assets | Where-Object { $_.version -notmatch '-[a-zA-Z]' }
+
     # Get github release asset for each version
     foreach ($toolVersion in $tool.versions) {
         $asset = $assets | Where-Object version -like $toolVersion `


### PR DESCRIPTION
# Description
This PR filters out pre-release version when installing toolcache (python, node, go)

#### Related issue:
## Check list
* [ ]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [ ]  Changes are tested and related VM images are successfully generated

