### PR TITLE
[all OSs] Edited toolset filtering to use Powershell version type cast

### DIFF
--- a/images/ubuntu/scripts/build/Install-Toolset.ps1
+++ b/images/ubuntu/scripts/build/Install-Toolset.ps1
@@ -35,14 +35,11 @@ foreach ($tool in $tools) {
     # Get versions manifest for current tool
     $assets = Invoke-RestMethod $tool.url
 
-    # Filter out pre-release versions
-    $assets = $assets | Where-Object { $_.version -notmatch '-[a-zA-Z]' }
-
     # Get github release asset for each version
     foreach ($toolVersion in $tool.versions) {
-        $asset = $assets | Where-Object version -like $toolVersion `
+        $asset = $assets | Where-Object { ($_.version -like $toolVersion) -and ($_.version -as [version] -ne $null) } `
             | Select-Object -ExpandProperty files `
-            | Where-Object { ($_.platform -eq $tool.platform) -and ($_.arch -eq $tool.arch) -and ($_.platform_version -eq $tool.platform_version)} `
+            | Where-Object { ($_.platform -eq $tool.platform) -and ($_.arch -eq $tool.arch) -and ($_.platform_version -eq $tool.platform_version) } `
             | Select-Object -First 1
 
         if (-not $asset) {


### PR DESCRIPTION
# Description
Improvement for toolset filtering logic: use built-in Powershell `[version]` type to check proper version syntax instead of regex

## Check list
* [ ]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [ ]  Changes are tested and related VM images are successfully generated

