### PR TITLE
Update delete-artifact action to v6.0.0

### DIFF
--- a/.github/workflows/ubuntu_trigger-build-new-templates.yml
+++ b/.github/workflows/ubuntu_trigger-build-new-templates.yml
@@ -229,7 +229,7 @@ jobs:
           artifacts: software-report.json,sbom.json.zip
         
       - name: Delete all artifacts associated with the run 
-        uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118 # 6.0.0
+        uses: geekyeggo/delete-artifact@176a747ab7e287e3ff4787bf8a148716375ca118  # v6.0.0
         with:
           name: |
             software-report.json


### PR DESCRIPTION
# Description
Improvement? This change updates the `geekyeggo/delete-artifact` action to version 6.0.0, ensuring compatibility with the latest features and fixes provided by the action. 
