### PR TITLE
[Ubuntu] Remove orphaned Microsoft Edge apt repo to fix NO_PUBKEY

### DIFF
--- a/images/ubuntu/scripts/build/install-microsoft-edge.sh
+++ b/images/ubuntu/scripts/build/install-microsoft-edge.sh
@@ -21,6 +21,7 @@ apt-get install --no-install-recommends microsoft-edge-stable
 
 rm $GPG_KEY
 rm $REPO_PATH
+rm -f /etc/apt/sources.list.d/*edge*
 
 echo "microsoft-edge $REPO_URL" >> $HELPER_SCRIPTS/apt-sources.txt
 


### PR DESCRIPTION
# Description
Bug fixing.

The `microsoft-edge-stable` deb package automatically registers its own apt repository during installation. Our `install-microsoft-edge.sh` script deleted its own repo file and GPG key after installing Edge, but did not remove the repo file auto-created by the Edge package itself. This left an orphaned repository entry without a corresponding GPG key, causing `NO_PUBKEY EB3E94ADBE1229CF` errors on any subsequent `apt-get update` call during the image build and at runtime.

The fix adds `rm -f /etc/apt/sources.list.d/*edge*` to remove all Edge-related repo files after installation. Edge is already installed in the image and does not need an apt repository on ephemeral runners.

#### Related issue:
## Check list
* [x]  Related issue / work item is attached
* [ ]  Tests are written (if applicable)
* [ ]  Documentation is updated (if applicable)
* [x]  Changes are tested and related VM images are successfully generated
