### PR TITLE
chore(deps): Renovate minimum release age 7 days

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -10,6 +10,7 @@
   prConcurrentLimit: 0,
   automerge: false,
   minimumReleaseAge: '7 days',
+  minimumReleaseAgeBehaviour: 'timestamp-required',
   enabledManagers: [
     'github-actions',
   ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -11,6 +11,7 @@
   automerge: false,
   minimumReleaseAge: '7 days',
   minimumReleaseAgeBehaviour: 'timestamp-required',
+  internalChecksFilter: 'strict',
   enabledManagers: [
     'github-actions',
   ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,7 @@
   prHourlyLimit: 0,
   prConcurrentLimit: 0,
   automerge: false,
+  minimumReleaseAge: '7 days',
   enabledManagers: [
     'github-actions',
   ],


### PR DESCRIPTION
# Description
Improvements to the Renovate configuration include setting a minimum release age of 7 days and adding an internal checks filter. These changes enhance the management of dependency updates and ensure stricter control over release timing.

#### Related issue:
N/A

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
