### PR TITLE
chore(deps): Update Renovate cron schedule

### DIFF
--- a/.github/workflows/tools_renovate.yml
+++ b/.github/workflows/tools_renovate.yml
@@ -3,7 +3,7 @@ name: Tools - Renovate
 
 "on":
   schedule:
-    - cron: "0 6 * * *"  # jeden Tag um 06:00 Uhr
+    - cron: "0 6 * * 6"  # Jeden Samstag um 06:00 Uhr
   workflow_dispatch:
     inputs:
       logLevel:

--- a/.github/workflows/tools_renovate.yml
+++ b/.github/workflows/tools_renovate.yml
@@ -3,7 +3,7 @@ name: Tools - Renovate
 
 "on":
   schedule:
-    - cron: "0 6 * * 6"  # Jeden Samstag um 06:00 Uhr
+    - cron: "0 5 * * 6"  # Jeden Samstag um 06:00 Uhr
   workflow_dispatch:
     inputs:
       logLevel:


### PR DESCRIPTION
# Description
Adjust the cron schedule to run Renovate every Saturday at 05:00 instead of 06:00. This change aims to optimize the timing of updates.

#### Related issue:
N/A

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated

