### PR TITLE
chore(deps): Enhance JSON validation by adding exemption for pinnedDetails

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -351,7 +351,9 @@
         "version": "14"
     },
     "cmake": {
-        "version": "3.31.6"
+        "version": "3.31.6",
+        "pinnedDetails": {
+            "reason": "Supply chain security - CMake"
     },
     "pwsh": {
         "version": "7.4"

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -354,6 +354,7 @@
         "version": "3.31.6",
         "pinnedDetails": {
             "reason": "Supply chain security - CMake"
+        }
     },
     "pwsh": {
         "version": "7.4"

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -321,7 +321,9 @@
         "version": "16"
     },
     "cmake": {
-        "version": "3.31.6"
+        "version": "3.31.6",
+        "pinnedDetails": {
+            "reason": "Supply chain security - CMake"
     },
     "pwsh": {
         "version": "7.4"

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -324,6 +324,7 @@
         "version": "3.31.6",
         "pinnedDetails": {
             "reason": "Supply chain security - CMake"
+        }
     },
     "pwsh": {
         "version": "7.4"


### PR DESCRIPTION
# Description
Improvement to JSON validation logic by allowing exemptions for `pinnedDetails` specifically for the `cmake` tool. This change aims to reduce unnecessary validation errors related to this tool, enhancing the overall user experience.

#### Related issue:
N/A

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
