### PR TITLE
[All OS] Default Node.js version changed from 20 to 22. Node.js 20 removed

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -32,7 +32,6 @@
             "platform" : "linux",
             "arch": "x64",
             "versions": [
-                "20.*",
                 "22.*",
                 "24.*"
             ]
@@ -295,7 +294,7 @@
         "version": "4"
     },
     "node": {
-        "default": "20"
+        "default": "22"
     },
     "node_modules": [
         {

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -30,7 +30,6 @@
             "platform" : "linux",
             "arch": "x64",
             "versions": [
-                "20.*",
                 "22.*",
                 "24.*"
             ]
@@ -273,7 +272,7 @@
         "version": "4"
     },
     "node": {
-        "default": "20"
+        "default": "22"
     },
     "node_modules": [
         {

--- a/images/ubuntu/toolsets/toolset-2604.json
+++ b/images/ubuntu/toolsets/toolset-2604.json
@@ -25,7 +25,6 @@
             "platform" : "linux",
             "arch": "x64",
             "versions": [
-                "20.*",
                 "22.*",
                 "24.*"
             ]


### PR DESCRIPTION
# Description
**Improvement / Bug fixing**

Remove Node.js 20 from all runner images and update the default Node.js version to 22 on images where Node.js 20 was the default.

Node.js 20 reached [end-of-life on April 30, 2026](https://github.com/nodejs/release#readme). This change:

* Removes `20.*` from the toolcache versions list in all toolset JSON files across Ubuntu images
* Updates the default Node.js version from `20` to `22` on images where Node.js 20 was the default (`ubuntu-22.04`, `ubuntu-24.04`)
* Images that already had Node.js 22 or 24 as the default are not affected (only `20.*` removed from toolcache)

After this change, only Node.js 22 and 24 remain pre-installed in the toolcache.

Image	Previous default	New default
`ubuntu-22.04`	20	**22**
`ubuntu-24.04`	20	**22**
`ubuntu-slim`	24	24 (unchanged)

#### Related issue:
* [ubuntu-latest default Node.js 20.20.2 unsupported #13833](https://github.com/actions/runner-images/issues/13833)
* [[All OS] Default Node.js version will be changed from 20 to 22 and Node.js 20 will be removed from runner images #14029](https://github.com/actions/runner-images/issues/14029)

## Check list
* [x]  Related issue / work item is attached
* [x]  Tests are written (if applicable)
* [x]  Documentation is updated (if applicable)
* [x]  Changes are tested and related VM images are successfully generated

