### PR TITLE
Fix packer command search patterns for HCL filenames

### DIFF
--- a/.github/workflows/ubuntu_trigger-build-new-templates.yml
+++ b/.github/workflows/ubuntu_trigger-build-new-templates.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Run `packer build`
         id: build
-        run: packer build -only "${{ inputs.hcl_filename }}*" ./images/ubuntu/templates/
+        run: packer build -only "${{ inputs.hcl_filename }}.*" ./images/ubuntu/templates/
         env:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
           HCLOUD_OBJECT_NAME: ${{ inputs.hcloud_name }}

--- a/.github/workflows/ubuntu_trigger-build-new-templates.yml
+++ b/.github/workflows/ubuntu_trigger-build-new-templates.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Run `packer validate`
         id: validate
-        run: packer validate -only "${{ inputs.hcl_filename }}*" ./images/ubuntu/templates/
+        run: packer validate -only "${{ inputs.hcl_filename }}.*" ./images/ubuntu/templates/
         env:
           HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
           HCLOUD_OBJECT_NAME: ${{ inputs.hcloud_name }}


### PR DESCRIPTION
# Description
Improvement. This change corrects the search pattern used in the `packer validate` and `packer build` commands to ensure they properly match HCL filenames. This adjustment enhances the reliability of the packer commands when processing templates.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated

