### PR TITLE
Add concurrency settings to build workflows

### DIFF
--- a/.github/workflows/ubuntu_build-template-for-22.04.yml
+++ b/.github/workflows/ubuntu_build-template-for-22.04.yml
@@ -26,6 +26,11 @@ env:
   os: "ubuntu22"
 
 
+concurrency:
+  group: "build-image"
+  cancel-in-progress: false
+
+
 jobs:
   Set-Variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/ubuntu_build-template-for-22.04.yml
+++ b/.github/workflows/ubuntu_build-template-for-22.04.yml
@@ -27,7 +27,7 @@ env:
 
 
 concurrency:
-  group: "build-image"
+  group: "build-image-ubuntu22"
   cancel-in-progress: false
 
 

--- a/.github/workflows/ubuntu_build-template-for-22.04.yml
+++ b/.github/workflows/ubuntu_build-template-for-22.04.yml
@@ -27,7 +27,7 @@ env:
 
 
 concurrency:
-  group: "build-image-ubuntu22"
+  group: "runner-image-build-${{ github.workflow }}"
   cancel-in-progress: false
 
 

--- a/.github/workflows/ubuntu_build-template-for-24.04.yml
+++ b/.github/workflows/ubuntu_build-template-for-24.04.yml
@@ -25,6 +25,11 @@ env:
   os: "ubuntu24"
 
 
+concurrency:
+  group: "build-image-ubuntu24"
+  cancel-in-progress: true
+
+
 jobs:
   Set-Variables:
     runs-on: ubuntu-latest

--- a/.github/workflows/ubuntu_build-template-for-24.04.yml
+++ b/.github/workflows/ubuntu_build-template-for-24.04.yml
@@ -26,7 +26,7 @@ env:
 
 
 concurrency:
-  group: "build-image-ubuntu24"
+  group: "runner-image-build-${{ github.workflow }}"
   cancel-in-progress: false
 
 

--- a/.github/workflows/ubuntu_build-template-for-24.04.yml
+++ b/.github/workflows/ubuntu_build-template-for-24.04.yml
@@ -27,7 +27,7 @@ env:
 
 concurrency:
   group: "build-image-ubuntu24"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 
 jobs:


### PR DESCRIPTION
# Description
Introduce concurrency settings to the Ubuntu 22.04 and 24.04 build workflows to prevent cancellation of in-progress builds. This improvement enhances build reliability and efficiency. 

#### Related issue:
N/A

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
