### PR TITLE
Remove  kernel information from software report for ubuntu-slim images

### DIFF
--- a/images/ubuntu-slim/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/ubuntu-slim/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -21,7 +21,6 @@ sudo chown -R ${env:USER}: $env:HOME
 # Software report
 $softwareReport = [SoftwareReport]::new("Ubuntu-Slim")
 $softwareReport.Root.AddToolVersion("OS Version:", $(Get-OSVersionFull))
-$softwareReport.Root.AddToolVersion("Kernel Version:", $(Get-KernelVersion))
 $softwareReport.Root.AddToolVersion("Image Version:", $env:IMAGE_VERSION)
 $softwareReport.Root.AddToolVersion("Systemd version:", $(Get-SystemdVersion))
 


### PR DESCRIPTION
# Description
This PR removes kernel-related information from the generated software report for ubuntu-slim runner images.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
