### PR TITLE
Add GitHub Copilot CLI to hosted runner images

### DIFF
--- a/images/ubuntu/scripts/build/install-copilot-cli.sh
+++ b/images/ubuntu/scripts/build/install-copilot-cli.sh
@@ -1,0 +1,88 @@
+#!/bin/bash -e
+################################################################################
+##  File:  install-copilot-cli.sh
+##  Desc:  Install GitHub Copilot CLI from GitHub Releases with SHA256 checksum
+##         verification, pinned to the version validated by the gh-aw agent
+##         compatibility matrix.
+##  Supply chain security: Copilot CLI - checksum validation
+################################################################################
+
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/install.sh
+source $HELPER_SCRIPTS/os.sh
+
+# Detect host architecture to pick the matching release asset and toolcache
+# subdirectory.
+if is_x64; then
+    arch="x64"
+elif is_arm64; then
+    arch="arm64"
+else
+    echo "Error: unsupported architecture $(uname -m)"
+    exit 1
+fi
+
+# Pin to the catch-all max-agent published in the gh-aw compatibility matrix
+# (https://github.com/github/gh-aw-actions/blob/main/.github/aw/compat.json).
+# This is the highest copilot CLI version validated against the current gh-aw
+# release line.
+#
+# Fail the bake on any fetch or parse failure (matches the install-awf.sh
+# pattern). The matrix is the single source of truth for which Copilot CLI
+# version is approved for the runner image; if it cannot be resolved we would
+# rather rebuild later than ship an unvalidated version.
+COMPAT_URL="https://raw.githubusercontent.com/github/gh-aw-actions/main/.github/aw/compat.json"
+
+echo "Fetching agent compatibility matrix from $COMPAT_URL..."
+compat_json=$(curl -fsSL --proto '=https' --proto-redir '=https' --retry 3 --retry-delay 2 "$COMPAT_URL") || {
+    echo "Error: Unable to fetch agent compatibility matrix from $COMPAT_URL."
+    exit 1
+}
+
+# Select the catch-all row (max-gh-aw == "*") and read its max-agent.
+# Use jq -e so a missing/null result exits non-zero and we surface a clear
+# error instead of silently installing whatever happens to be on the latest tag.
+copilot_version=$(echo "$compat_json" | jq -er '.["agent-compat-v1"].copilot[] | select(.["max-gh-aw"] == "*") | .["max-agent"]') || {
+    echo "Error: catch-all max-agent (max-gh-aw == \"*\") not found in compat.json."
+    exit 1
+}
+
+# Guard against malformed matrix entries: there must be exactly one catch-all
+# row, and its value must be a SemVer string.
+if [[ $(echo "$copilot_version" | wc -l) -ne 1 ]]; then
+    echo "Error: compat.json has more than one catch-all copilot row; expected exactly one."
+    echo "Got:"
+    echo "$copilot_version"
+    exit 1
+fi
+if ! [[ "$copilot_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+    echo "Error: compat.json catch-all max-agent ('$copilot_version') is not a valid SemVer version."
+    exit 1
+fi
+
+# Download the release tarball for this arch.
+tarball_name="copilot-linux-${arch}.tar.gz"
+release_base="https://github.com/github/copilot-cli/releases/download/v${copilot_version}"
+tarball_path=$(download_with_retry "${release_base}/${tarball_name}")
+
+# Supply chain security - Copilot CLI: verify SHA256 against the published
+# SHA256SUMS.txt from the same release.
+external_hash=$(get_checksum_from_url "${release_base}/SHA256SUMS.txt" "$tarball_name" "SHA256")
+use_checksum_comparison "$tarball_path" "$external_hash"
+
+# Install into the agent tool cache so the gh-aw-actions/setup action's
+# tc.find("copilot-cli", ...) lookup succeeds on hosted runners. Layout:
+#   $AGENT_TOOLSDIRECTORY/copilot-cli/<version>/<arch>/bin/copilot
+#   $AGENT_TOOLSDIRECTORY/copilot-cli/<version>/<arch>.complete
+# Mirrors the conventions used by install-awf.sh and install-codeql-bundle.sh.
+copilot_toolcache_path="$AGENT_TOOLSDIRECTORY/copilot-cli/$copilot_version/$arch"
+mkdir -p "$copilot_toolcache_path/bin"
+
+echo "Installing GitHub Copilot CLI v$copilot_version into $copilot_toolcache_path..."
+tar -xzf "$tarball_path" -C "$copilot_toolcache_path/bin"
+rm -f "$tarball_path"
+
+# Mark the tool-cache entry complete so @actions/tool-cache#find returns it.
+touch "$copilot_toolcache_path.complete"
+
+invoke_tests "Tools" "Copilot CLI"

--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -428,3 +428,26 @@ Describe "AWF" -Skip:(Test-IsUbuntu22) {
         $bundlePath | Should -Exist
     }
 }
+
+Describe "Copilot CLI" -Skip:(Test-IsUbuntu22) {
+    It "Copilot CLI toolcache directory exists" {
+        $copilotPath = Join-Path $env:AGENT_TOOLSDIRECTORY "copilot-cli"
+        $copilotPath | Should -Exist
+    }
+
+    It "Copilot CLI binary exists in toolcache" {
+        $arch = if ((uname -m) -eq "aarch64") { "arm64" } else { "x64" }
+        $copilotPath = Join-Path $env:AGENT_TOOLSDIRECTORY "copilot-cli"
+        $latestVersion = Get-ChildItem -Path $copilotPath -Directory | Sort-Object -Property { [version]$_.Name } -Descending | Select-Object -First 1
+        $binPath = Join-Path $latestVersion.FullName $arch "bin" "copilot"
+        $binPath | Should -Exist
+    }
+
+    It "Copilot CLI toolcache .complete marker exists" {
+        $arch = if ((uname -m) -eq "aarch64") { "arm64" } else { "x64" }
+        $copilotPath = Join-Path $env:AGENT_TOOLSDIRECTORY "copilot-cli"
+        $latestVersion = Get-ChildItem -Path $copilotPath -Directory | Sort-Object -Property { [version]$_.Name } -Descending | Select-Object -First 1
+        $completeMarker = Join-Path $latestVersion.FullName "$arch.complete"
+        $completeMarker | Should -Exist
+    }
+}

--- a/images/ubuntu/templates/build.ubuntu-24_04-arm64.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-24_04-arm64.pkr.hcl
@@ -130,6 +130,7 @@ build {
       "${path.root}/../scripts/build/install-nginx.sh",
       "${path.root}/../scripts/build/install-nvm.sh",
       "${path.root}/../scripts/build/install-nodejs.sh",
+      "${path.root}/../scripts/build/install-copilot-cli.sh",
       "${path.root}/../scripts/build/install-bazel.sh",
       "${path.root}/../scripts/build/install-php.sh",
       "${path.root}/../scripts/build/install-pulumi.sh",

--- a/images/ubuntu/templates/build.ubuntu-24_04.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-24_04.pkr.hcl
@@ -136,6 +136,7 @@ build {
       "${path.root}/../scripts/build/install-nginx.sh",
       "${path.root}/../scripts/build/install-nvm.sh",
       "${path.root}/../scripts/build/install-nodejs.sh",
+      "${path.root}/../scripts/build/install-copilot-cli.sh",
       "${path.root}/../scripts/build/install-bazel.sh",
       "${path.root}/../scripts/build/install-php.sh",
       "${path.root}/../scripts/build/install-postgresql.sh",

--- a/images/ubuntu/templates/build.ubuntu-26_04-arm64.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-26_04-arm64.pkr.hcl
@@ -129,6 +129,7 @@ build {
       "${path.root}/../scripts/build/install-nginx.sh",
       "${path.root}/../scripts/build/install-nvm.sh",
       "${path.root}/../scripts/build/install-nodejs.sh",
+      "${path.root}/../scripts/build/install-copilot-cli.sh",
       "${path.root}/../scripts/build/install-bazel.sh",
       "${path.root}/../scripts/build/install-php.sh",
       "${path.root}/../scripts/build/install-ruby.sh",

--- a/images/ubuntu/templates/build.ubuntu-26_04.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-26_04.pkr.hcl
@@ -151,6 +151,7 @@ build {
       "${path.root}/../scripts/build/install-nginx.sh",
       "${path.root}/../scripts/build/install-nvm.sh",
       "${path.root}/../scripts/build/install-nodejs.sh",
+      "${path.root}/../scripts/build/install-copilot-cli.sh",
       "${path.root}/../scripts/build/install-bazel.sh",
       "${path.root}/../scripts/build/install-php.sh",
       "${path.root}/../scripts/build/install-postgresql.sh",


### PR DESCRIPTION
Install `@github/copilot` into the **agent tool cache** during image bake for Ubuntu 24.04 and 26.04. The CLI is staged at `$AGENT_TOOLSDIRECTORY/copilot-cli/<version>/x64/` with the matching `x64.complete` marker file, so a runtime consumer using `@actions/tool-cache` can find it via `tc.find("copilot-cli", ...)` and expose it on PATH with `core.addPath`.

This enables agentic workflows that use the Copilot engine to skip the runtime `npm install` step on a cache hit, reducing workflow startup time. The toolcache version is read from `https://raw.githubusercontent.com/github/gh-aw-actions/main/.github/aw/compat.json` (the agentic-workflows compatibility matrix), specifically the `max-agent` value on the catch-all row.

### Changes

- `images/ubuntu/scripts/build/install-copilot-cli.sh` — fetch the toolcache version from `compat.json`, install via `npm install -g --prefix <toolcache>/x64/`, write `x64.complete` marker. Hard-fails the bake on fetch/parse failure (matches `install-awf.sh` semantics).
- `images/ubuntu/scripts/tests/Tools.Tests.ps1` — Pester test verifying the toolcache layout (`/opt/hostedtoolcache/copilot-cli/*/x64/bin/copilot`, `x64.complete` marker present). Mirrors the existing AWF test block.
- `images/ubuntu/templates/build.ubuntu-24_04.pkr.hcl` — invoke `install-copilot-cli.sh` in the build (after `install-nodejs.sh` so `npm` is available).
- `images/ubuntu/templates/build.ubuntu-26_04.pkr.hcl` — same.

### Why toolcache instead of system PATH

A runtime consumer needs to (a) pick a specific version that satisfies a semver range and (b) ensure the binary is on PATH for the agent step. The standard pattern for both is `@actions/tool-cache`: `tc.find("copilot-cli", range)` returns the cached path, `core.addPath(<path>/bin)` exposes it. That requires the on-disk layout to be `$RUNNER_TOOL_CACHE/<tool>/<version>/<arch>/` with a `.complete` marker — which is exactly what this script produces. AWF (`install-awf.sh` in this same repo) uses the same pattern.

### Backward compatibility

This change is **no-op** for workflows that don't use `@actions/tool-cache` to find the Copilot CLI. The bake step neither shadows nor removes anything from the global PATH (the previous global `npm install -g` location is replaced because nothing else needs the binary there). Workflows that today install Copilot CLI via `npm install -g` at runtime keep doing so unchanged.
