### PR TITLE
[Ubuntu] Pin sbt to 1.x to avoid sbt 2.x JDK 17+ requirement

### DIFF
--- a/images/ubuntu/scripts/build/install-sbt.sh
+++ b/images/ubuntu/scripts/build/install-sbt.sh
@@ -6,8 +6,10 @@
 
 source $HELPER_SCRIPTS/install.sh
 
-# Install latest sbt release
-download_url=$(resolve_github_release_asset_url "sbt/sbt" "endswith(\".tgz\")" "latest")
+# Install the latest sbt 1.x release.
+# sbt 2.x requires JDK 17 or above, while the default JDK on Ubuntu 22.04 is JDK 11.
+# See https://github.com/actions/runner-images/issues/14236
+download_url=$(resolve_github_release_asset_url "sbt/sbt" "endswith(\".tgz\")" "^1\\..+" "false" "true")
 archive_path=$(download_with_retry "$download_url")
 tar zxf "$archive_path" -C /usr/share
 ln -s /usr/share/sbt/bin/sbt /usr/bin/sbt


### PR DESCRIPTION
sbt 2.0.0 requires JDK 17 or above, which breaks the image build on Ubuntu 22.04 (default JDK 11) and Windows Server 2022 (default JDK 8).

- Ubuntu: filter releases to the latest 1.x via resolve_github_release_asset_url
- Windows: pin chocolatey sbt to 1.12.12

Fixes #14236

# Description

Bug fixing.

sbt `2.0.0` was released and now requires **JDK 17 or above**. The sbt
installation scripts always pull the **latest** release, so on images whose
default JDK is older than 17 the build now fails at the `sbt --version`
validation step: 
[error] sbt 2.x requires JDK 17 or above, but you have JDK 11


Affected images (default JDK < 17, sbt installed):
- **Ubuntu 22.04 x64** — default JDK 11
- **Windows Server 2022** — default JDK 8

This PR pins sbt to the latest **1.x** release so the tool keeps installing
successfully without changing the image's default JDK (which would be a
breaking change for users).

## How it works

- **Ubuntu** (`images/ubuntu/scripts/build/install-sbt.sh`): the GitHub release
  lookup now filters to the `^1\..+` tag pattern (latest 1.x) instead of
  `latest`.
- **Windows** (`images/windows/scripts/build/Install-Sbt.ps1`): the Chocolatey
  package is pinned to `1.12.12` (latest 1.x).

No default-JDK change, no breaking change. Users who need sbt 2.x can switch the
active JDK to 17+ in their workflow (e.g. via `actions/setup-java`), since
JDK 17/21/25 are present on the images.

## Test

https://github.com/github/hosted-runners-images/actions/runs/27609835405

#### Related issue:
Fixes https://github.com/actions/runner-images/issues/14236

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
