### PR TITLE
Disable archive option for artifact upload

### DIFF
--- a/.github/workflows/ubuntu_trigger_02-build-snaphot.yml
+++ b/.github/workflows/ubuntu_trigger_02-build-snaphot.yml
@@ -152,6 +152,7 @@ jobs:
           if-no-files-found: error
           overwrite: true
           retention-days: 1
+          archive: false
 
       - name: Remove ${{ inputs.app_sw_report_file_name }} and ${{ inputs.app_sw_sbom_file_name }}
         shell: bash


### PR DESCRIPTION
# Description
Disables the archive option for artifact uploads to prevent unintended behavior during the upload process.

#### Related issue: None

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated


