### PR TITLE
Remove swap file configuration from Ubuntu 26 build

### DIFF
--- a/images/ubuntu/templates/build.ubuntu-26_04.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-26_04.pkr.hcl
@@ -14,17 +14,6 @@ build {
   }
 
   provisioner "shell" {
-    inline = [
-      "echo 'Create swap file with 4GB'",
-      "sudo fallocate -l 4G /swapfile",
-      "sudo chmod 600 /swapfile",
-      "sudo mkswap /swapfile",
-      "sudo swapon /swapfile",
-      "free -h"
-    ]
-  }
-
-  provisioner "shell" {
     execute_command = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     inline          = ["mkdir ${var.image_folder}", "chmod 777 ${var.image_folder}"]
   }

--- a/images/ubuntu/templates/build.ubuntu-26_04.pkr.hcl
+++ b/images/ubuntu/templates/build.ubuntu-26_04.pkr.hcl
@@ -248,14 +248,6 @@ build {
   }
 
   provisioner "shell" {
-    inline = [
-      "sudo swapoff /swapfile || true",
-      "sudo rm -f /swapfile",
-      "free -h"
-    ]
-  }
-
-  provisioner "shell" {
     inline           = ["cloud-init clean --machine-id --seed --logs", "rm -rf /run/cloud-init/\\*", "rm -rf /var/lib/cloud/\\*"]
     valid_exit_codes = [0, 2]
   }


### PR DESCRIPTION
# Description
Eliminate the creation and cleanup of swap files in the Ubuntu 26 build configuration to streamline the setup process. This change simplifies the build process and reduces unnecessary resource allocation.

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
