### PR TITLE
Add ubuntu-26.04 to the matrix for snapshot deletion workflow

### DIFF
--- a/.github/workflows/tools_delete_old_vm_templates.yml
+++ b/.github/workflows/tools_delete_old_vm_templates.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ['ubuntu-22.04', 'ubuntu-24.04']
+        image: ['ubuntu-22.04', 'ubuntu-24.04', 'ubuntu-26.04']
 
     steps:
       - name: "Check if variable 'keep_snapshots' exist"

--- a/.github/workflows/tools_delete_old_vm_templates.yml
+++ b/.github/workflows/tools_delete_old_vm_templates.yml
@@ -10,7 +10,7 @@ permissions:
   
 jobs:
   Delete:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
# Description
Enhance the snapshot deletion workflow by adding support for the ubuntu-26.04 image. This improvement allows for broader compatibility and testing across different Ubuntu versions. 
#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
