### PR TITLE
Update default server type to cpx32 in Ubuntu build templates

### DIFF
--- a/.github/workflows/ubuntu_build-template-for-22.04.yml
+++ b/.github/workflows/ubuntu_build-template-for-22.04.yml
@@ -17,7 +17,7 @@ name: Ubuntu - Build template for Ubuntu 22.04
         required: true
         options:
           - cx33
-          - cpx22
+          - cpx32
           - ccx13
         default: "cx33"
 

--- a/.github/workflows/ubuntu_build-template-for-22.04.yml
+++ b/.github/workflows/ubuntu_build-template-for-22.04.yml
@@ -19,7 +19,7 @@ name: Ubuntu - Build template for Ubuntu 22.04
           - cx33
           - cpx32
           - ccx13
-        default: "cx33"
+        default: "cpx32"
 
 
 env:

--- a/.github/workflows/ubuntu_build-template-for-24.04.yml
+++ b/.github/workflows/ubuntu_build-template-for-24.04.yml
@@ -17,7 +17,7 @@ name: Ubuntu - Build template for Ubuntu 24.04
         required: true
         options:
           - cx33
-          - cpx22
+          - cpx32
           - ccx13
         default: "cx33"
 

--- a/.github/workflows/ubuntu_build-template-for-24.04.yml
+++ b/.github/workflows/ubuntu_build-template-for-24.04.yml
@@ -19,7 +19,7 @@ name: Ubuntu - Build template for Ubuntu 24.04
           - cx33
           - cpx32
           - ccx13
-        default: "cx33"
+        default: "cpx32"
 
 
 env:

--- a/.github/workflows/ubuntu_build-template-for-26.04.yml
+++ b/.github/workflows/ubuntu_build-template-for-26.04.yml
@@ -17,7 +17,7 @@ name: Ubuntu - Build template for Ubuntu 26.04
         required: true
         options:
           - cx33
-          - cpx22
+          - cpx32
           - ccx13
         default: "cx33"
 

--- a/.github/workflows/ubuntu_build-template-for-26.04.yml
+++ b/.github/workflows/ubuntu_build-template-for-26.04.yml
@@ -19,7 +19,7 @@ name: Ubuntu - Build template for Ubuntu 26.04
           - cx33
           - cpx32
           - ccx13
-        default: "cx33"
+        default: "cpx32"
 
 
 env:


### PR DESCRIPTION
# Description
Improve the Ubuntu build templates by updating the default server type from cpx22 to cpx32 for versions 22.04, 24.04, and 26.04. This change enhances compatibility and performance with the latest server configurations. 

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated
