### PR TITLE
Remove GitHub PR labels from metadata output in workflow

### DIFF
--- a/.github/workflows/ubuntu_trigger_01-collect-metadata.yml
+++ b/.github/workflows/ubuntu_trigger_01-collect-metadata.yml
@@ -191,7 +191,7 @@ jobs:
       loc_gh_tag: "${{ inputs.os }}/${{ steps.metadata.outputs.version_long }}"
 
       loc_gh_release_title: "${{ steps.os.outputs.os_dist_cs }} ${{ steps.os.outputs.os_version_cs }} (${{ steps.metadata.outputs.version_full }}) Image Update"
-      loc_gh_pr_labels: "${{ steps.os.outputs.gh_pr_labels }}, ${{ inputs.os }}/${{ steps.metadata.outputs.version_long }}"
+      loc_gh_pr_labels: "${{ steps.os.outputs.gh_pr_labels }}"
       loc_gh_release_no: "${{ steps.metadata.outputs.version_full }}"
 
       loc_gh_pr_title: "${{ steps.os.outputs.os_dist_cs }} ${{ steps.os.outputs.os_version_cs }} (${{ steps.metadata.outputs.version_full }}) Image Update"


### PR DESCRIPTION
# Description
The change simplifies the metadata output in the workflow by removing GitHub PR labels. This adjustment enhances clarity and focuses on essential information without the additional labels. 
#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated


