### PR TITLE
[ubuntu] Add libicu-dev package explicitly

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2204-arm64.json
@@ -148,6 +148,7 @@
             "libxkbfile-dev",
             "libxss1",
             "libssl-dev",
+            "libicu-dev",
             "locales",
             "mercurial",
             "openssh-client",

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -155,6 +155,7 @@
             "libxkbfile-dev",
             "libxss1",
             "libssl-dev",
+            "libicu-dev",
             "locales",
             "mercurial",
             "openssh-client",

--- a/images/ubuntu/toolsets/toolset-2404-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2404-arm64.json
@@ -129,6 +129,7 @@
             "libyaml-dev",
             "libtool",
             "libssl-dev",
+            "libicu-dev",
             "libgbm-dev",
             "libsqlite3-dev",
             "locales",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -133,6 +133,7 @@
             "libyaml-dev",
             "libtool",
             "libssl-dev",
+            "libicu-dev",
             "libsqlite3-dev",
             "locales",
             "mercurial",

--- a/images/ubuntu/toolsets/toolset-2604-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2604-arm64.json
@@ -120,6 +120,7 @@
             "libyaml-dev",
             "libtool",
             "libssl-dev",
+            "libicu-dev",
             "libgbm-dev",
             "libsqlite3-dev",
             "locales",

--- a/images/ubuntu/toolsets/toolset-2604.json
+++ b/images/ubuntu/toolsets/toolset-2604.json
@@ -124,6 +124,7 @@
             "libyaml-dev",
             "libtool",
             "libssl-dev",
+            "libicu-dev",
             "libsqlite3-dev",
             "locales",
             "openssh-client",


### PR DESCRIPTION
# Description
`libicu-dev` package on `ubuntu-22` and `ubuntu-24` are installed as dependencies of other apt packages.
This PR adds explicit `libicu-dev` installation across all ubuntu images

#### Related issue: https://github.com/actions/runner-images/issues/14259

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
