### PR TITLE
[ubuntu26] Pin podman firewall backend to iptables

### DIFF
--- a/images/ubuntu/scripts/build/install-container-tools.sh
+++ b/images/ubuntu/scripts/build/install-container-tools.sh
@@ -30,4 +30,12 @@ apt-get install ${install_packages[@]}
 mkdir -p /etc/containers
 printf "[registries.search]\nregistries = ['docker.io', 'quay.io']\n" | tee /etc/containers/registries.conf
 
+# https://github.com/actions/runner-images/issues/14230
+# netavark on ubuntu 26 defaults to nftables and fails name resolution
+if is_ubuntu26; then
+    mkdir -p /etc/containers/containers.conf.d
+    printf '[network]\nfirewall_driver = "iptables"\n' | tee /etc/containers/containers.conf.d/99-fix-firewall.conf
+    podman network reload --all 2>/dev/null
+fi
+
 invoke_tests "Tools" "Containers"

--- a/images/ubuntu/toolsets/toolset-2204-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2204-arm64.json
@@ -148,6 +148,7 @@
             "libxkbfile-dev",
             "libxss1",
             "libssl-dev",
+            "libicu-dev",
             "locales",
             "mercurial",
             "openssh-client",

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -155,6 +155,7 @@
             "libxkbfile-dev",
             "libxss1",
             "libssl-dev",
+            "libicu-dev",
             "locales",
             "mercurial",
             "openssh-client",

--- a/images/ubuntu/toolsets/toolset-2404-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2404-arm64.json
@@ -129,6 +129,7 @@
             "libyaml-dev",
             "libtool",
             "libssl-dev",
+            "libicu-dev",
             "libgbm-dev",
             "libsqlite3-dev",
             "locales",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -133,6 +133,7 @@
             "libyaml-dev",
             "libtool",
             "libssl-dev",
+            "libicu-dev",
             "libsqlite3-dev",
             "locales",
             "mercurial",

--- a/images/ubuntu/toolsets/toolset-2604-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2604-arm64.json
@@ -120,6 +120,7 @@
             "libyaml-dev",
             "libtool",
             "libssl-dev",
+            "libicu-dev",
             "libgbm-dev",
             "libsqlite3-dev",
             "locales",

--- a/images/ubuntu/toolsets/toolset-2604.json
+++ b/images/ubuntu/toolsets/toolset-2604.json
@@ -124,6 +124,7 @@
             "libyaml-dev",
             "libtool",
             "libssl-dev",
+            "libicu-dev",
             "libsqlite3-dev",
             "locales",
             "openssh-client",


### PR DESCRIPTION
# Description
`netavark` on ubuntu-26 has been bumped 1.4.0 -> 1.16.1 as part of the podman installation, causing issues with `nftables` and name resolution. This PR pins podman firewall backend to `iptables`.

#### Related issue: https://github.com/actions/runner-images/issues/14230

## Check list
- [x] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
