### PR TITLE
[Ubuntu] Fix install-pypy.sh for PyPy .tar.gz archives

### DIFF
--- a/images/ubuntu/scripts/build/install-pypy.sh
+++ b/images/ubuntu/scripts/build/install-pypy.sh
@@ -13,7 +13,7 @@ install_pypy() {
     local package_url=$1
 
     package_tar_name=$(echo "$package_url" | awk -F/ '{print $NF}')
-    package_name=${package_tar_name/.tar.bz2/}
+    package_name=${package_tar_name%.tar.*}
 
     echo "Downloading tar archive '$package_name'"
     package_tar_temp_path=$(download_with_retry $package_url)


### PR DESCRIPTION
# Description

**Bug fix**

Fix PyPy installation on Ubuntu x64 images after PyPy switched its Linux x64 release archives from `.tar.bz2` to `.tar.gz`.

`images/ubuntu/scripts/build/install-pypy.sh` derived the extracted-folder name by stripping only a hardcoded `.tar.bz2` suffix:

```bash
package_name=${package_tar_name/.tar.bz2/}
```

PyPy now publishes `.tar.gz` archives for Linux x64 (observed with PyPy 7.3.23 in [`versions.json`](https://downloads.python.org/pypy/versions.json)). With a `.tar.gz` download the substitution above is a no-op, so `package_name` keeps the `.tar.gz` extension and the script references a path that does not exist (`/tmp/pypy3.11-v7.3.23-linux64.tar.gz/bin/pypy3`). Invoking PyPy from that path fails and aborts the build:

```
/tmp/pypy3.11-v7.3.23-linux64.tar.gz/bin/pypy3: Not a directory
Script exited with non-zero exit status: 126
```

This broke every Ubuntu x64 image build (Ubuntu 22.04 / 24.04 / 26.04).

**Fix:** strip any `.tar.*` archive suffix instead of hardcoding `.tar.bz2`, so the extracted-folder name matches the archive's top-level directory regardless of the compression format:

```bash
package_name=${package_tar_name%.tar.*}
```

This handles both `.tar.gz` and `.tar.bz2` (and any future format).

#### Related issue:
https://github.com/github/hosted-runners-images/issues/851

## Check list
- [ ] Related issue / work item is attached
- [x] Tests are written (if applicable) — covered by the existing PyPy image validation tests
- [x] Documentation is updated (if applicable) — n/a (image readmes are regenerated by the build)
- [x] Changes are tested and related VM images are successfully generated

### Build results

| Image | Status | Link |
|---|---|---|
| Ubuntu 24.04 | SUCCESS | https://github.com/actions/runner-images-ci/actions/runs/29009970179 |

> **Note:** The fix is in the shared `images/ubuntu/scripts/build/install-pypy.sh`, which is used by all Ubuntu x64 builds (22.04 / 24.04 / 26.04). The Ubuntu 24.04 validation build confirms PyPy 7.3.23 (`.tar.gz`) now installs successfully (`Put '7.3.23' to PYPY_VERSION file`, `install-pypy.sh` completed in ~36s) and the image is generated with all Pester tests passing.