### PR TITLE
Remove archive option from artifact upload step

### DIFF
--- a/.github/workflows/ubuntu_trigger_02-build-snaphot.yml
+++ b/.github/workflows/ubuntu_trigger_02-build-snaphot.yml
@@ -152,7 +152,6 @@ jobs:
           if-no-files-found: error
           overwrite: true
           retention-days: 1
-          archive: false
 
       - name: Remove ${{ inputs.app_sw_report_file_name }} and ${{ inputs.app_sw_sbom_file_name }}
         shell: bash


### PR DESCRIPTION
# Description
Improvement. This change removes the archive option from the artifact upload step. So that the archive sbom.json.zip can once again be attached to releases.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated