### PR TITLE
Fix GitHub Actions output naming for consistency

### DIFF
--- a/.github/workflows/ubuntu_trigger_01-collect-metadata.yml
+++ b/.github/workflows/ubuntu_trigger_01-collect-metadata.yml
@@ -188,7 +188,7 @@ jobs:
 
     outputs:
       loc_gh_branch_name: "releases/${{ inputs.os }}/${{ steps.metadata.outputs.version_long }}"
-      loc_gh_tag: "${{ inputs.os }}/${{ steps.metadata.outputs.version_long }}"
+      loc_gh_tag: "${{ inputs.os }}/${{ steps.metadata.outputs.version_full }}"
 
       loc_gh_release_title: "${{ steps.os.outputs.os_dist_cs }} ${{ steps.os.outputs.os_version_cs }} (${{ steps.metadata.outputs.version_full }}) Image Update"
       loc_gh_pr_labels: "${{ steps.os.outputs.gh_pr_labels }}"

--- a/.github/workflows/ubuntu_trigger_01-collect-metadata.yml
+++ b/.github/workflows/ubuntu_trigger_01-collect-metadata.yml
@@ -187,7 +187,7 @@ jobs:
           echo "version_short=${current_date}" >> "$GITHUB_OUTPUT"
 
     outputs:
-      loc_gh_branch_name: "releases/${{ inputs.os }}/${{ steps.metadata.outputs.version_long }}"
+      loc_gh_branch_name: "releases/${{ inputs.os }}/${{ steps.metadata.outputs.version_full }}"
       loc_gh_tag: "${{ inputs.os }}/${{ steps.metadata.outputs.version_full }}"
 
       loc_gh_release_title: "${{ steps.os.outputs.os_dist_cs }} ${{ steps.os.outputs.os_version_cs }} (${{ steps.metadata.outputs.version_full }}) Image Update"

--- a/.github/workflows/ubuntu_trigger_01-collect-metadata.yml
+++ b/.github/workflows/ubuntu_trigger_01-collect-metadata.yml
@@ -191,7 +191,7 @@ jobs:
       loc_gh_tag: "${{ inputs.os }}/${{ steps.metadata.outputs.version_full }}"
 
       loc_gh_release_title: "${{ steps.os.outputs.os_dist_cs }} ${{ steps.os.outputs.os_version_cs }} (${{ steps.metadata.outputs.version_full }}) Image Update"
-      loc_gh_pr_labels: "${{ steps.os.outputs.gh_pr_labels }}"
+      loc_gh_pr_labels: "${{ steps.os.outputs.gh_pr_labels }}, ${{ steps.os.outputs.os_dist }}-${{ steps.os.outputs.os_version }}/${{ steps.metadata.outputs.version_long }}"
       loc_gh_release_no: "${{ steps.metadata.outputs.version_full }}"
 
       loc_gh_pr_title: "${{ steps.os.outputs.os_dist_cs }} ${{ steps.os.outputs.os_version_cs }} (${{ steps.metadata.outputs.version_full }}) Image Update"


### PR DESCRIPTION
Improvement to GitHub Actions outputs for better consistency in naming conventions. The changes ensure that the branch name and tag use the full version, and PR labels now include the OS distribution and version for clarity.

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated

