### PR TITLE
[Ubuntu] Fix podman crun selection and /usr, /etc ownership broken by the podman bundle install- #14480

### DIFF
--- a/images/ubuntu/scripts/build/install-container-tools.sh
+++ b/images/ubuntu/scripts/build/install-container-tools.sh
@@ -34,10 +34,27 @@ install_podman_static() {
     archive_path=$(download_with_retry "$archive_url")
     use_checksum_comparison "$archive_path" "$checksum"
 
-    # The bundle ships ./usr and ./etc under a single top-level directory
-    tar -xzf "$archive_path" -C / --strip-components=1 \
+    # The bundle ships ./usr and ./etc under a single top-level directory.
+    # Every archive entry is stored as uid/gid 1001 (`runner`) because the bundle is
+    # built on a GitHub Actions runner, and the archive also carries the `usr` and
+    # `etc` directory entries themselves. As root, tar restores that ownership by
+    # default and hands /usr and /etc to the unprivileged user, so keep the metadata
+    # of the existing system directories untouched.
+    # https://github.com/actions/runner-images/issues/14477
+    tar -xzf "$archive_path" -C / --strip-components=1 --no-same-owner --no-overwrite-dir \
         "podman-linux-${arch}/usr" "podman-linux-${arch}/etc"
     rm -f "$archive_path"
+
+    # podman resolves its OCI runtime from a built-in list of absolute paths in which
+    # /usr/bin/crun precedes /usr/local/bin/crun, and the bundle does not pin the path
+    # either, so podman picks the outdated crun that buildah pulls in from apt (1.14.1
+    # on 24.04) instead of the one shipped with the bundle. That crun rejects the
+    # ociVersion written by podman 5.x with "unknown version specified". Only the path
+    # is corrected, and the drop-in is named to load first so user drop-ins still win.
+    # https://github.com/actions/runner-images/issues/14473
+    mkdir -p /etc/containers/containers.conf.d
+    printf '[engine.runtimes]\ncrun = ["/usr/local/bin/crun"]\n' \
+        | tee /etc/containers/containers.conf.d/00-fix-runtime.conf
 
     # Ubuntu >= 23.10 restricts unprivileged user namespaces via AppArmor
     # (kernel.apparmor_restrict_unprivileged_userns=1). The distro podman package

--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -323,12 +323,27 @@ Describe "Containers" {
         "podman network rm test-net" | Should -ReturnZeroExitCode
     }
 
+    # https://github.com/actions/runner-images/issues/14473
+    It "podman uses the crun shipped with the podman bundle" -Skip:(Test-IsUbuntu26) {
+        "podman info --format '{{.Host.OCIRuntime.Path}}'" | Should -OutputTextMatchingRegex "/usr/local/bin/crun"
+    }
+
     # https://github.com/actions/runner-images/issues/14406
     # registries.conf must be valid v2 format; a v1 file is rejected by newer podman.
     It "podman registries.conf" {
         "podman info" | Should -ReturnZeroExitCode
         "podman info" | Should -OutputTextMatchingRegex "docker.io"
         "podman info" | Should -OutputTextMatchingRegex "quay.io"
+    }
+
+    # https://github.com/actions/runner-images/issues/14477
+    It "<Directory> is owned by root" -TestCases @(
+        @{ Directory = "/usr" }
+        @{ Directory = "/etc" }
+        @{ Directory = "/usr/local" }
+        @{ Directory = "/usr/local/bin" }
+    ) {
+        $(stat -c "%U" $Directory) | Should -Be "root"
     }
 
 }


### PR DESCRIPTION
# Description
This is a bug fix. It covers two regressions that come from the same change  (the podman static bundle install added in #14412).

**Related issues:** [#14473](https://github.com/actions/runner-images/issues/14473), [#14477](https://github.com/actions/runner-images/issues/14477), [#14478](https://github.com/actions/runner-images/issues/14478)

## 1. podman uses the wrong crun (#14473)

The image ends up with two cruns: the current one from the bundle in `/usr/local/bin`, and the old distro one in `/usr/bin` that `buildah` depends on. Podman does not use `PATH` to find its runtime, it checks a fixed list of paths where `/usr/bin` comes first. Because of this it picks the old one (1.14.1 on 24.04, 0.17 on 22.04). That crun rejects the config podman 5.x writes, so every `podman run` and `podman build` fails:

```
Error: OCI runtime error: crun: unknown version specified
```

**Fix:** write a `containers.conf.d` drop-in telling podman which crun to use. 

## 2. /usr and /etc become owned by `runner` (#14477)

The bundle archive is built on a GitHub Actions runner, so every entry inside is recorded as owned by uid 1001 (`runner`), including the `usr` and `etc` directory entries themselves. The script unpacks it as root straight into `/`, and tar restores that stored ownership, handing `/usr` and `/etc` to an unprivileged user.

**Fix:** extract with `--no-same-owner --no-overwrite-dir`, so files land as `root` and existing system directories are left untouched.

Ubuntu 26.04 is unaffected by both: it installs podman from apt with crun 1.21 and never extracts the bundle. Note that 22.04 is affected as well, not only 24.04 as issue #14473 suggests. No breaking changes.

## 3. `sudo timedatectl set-timezone` fails (#14478)

Same cause as #2, so fix 2 covers it and no extra change is needed. Confirmed on a rolled-back (healthy) image by changing only the ownership and back.
- [Evidence run](https://github.com/v-dunjadenic/runner-images/actions/runs/30638756543)

```
/usr, /etc owned by root    -> set-timezone OK
/usr, /etc owned by runner  -> Failed to set time zone: Access denied
/usr, /etc owned by root    -> set-timezone OK
```
## Validation

- [Full run](https://github.com/v-dunjadenic/runner-images/actions/runs/30632890655)
- [Source test workflow with explanation](https://github.com/v-dunjadenic/runner-images/actions/runs/30632890655/workflow)

The workflow runs the real build script from this branch on hosted runners, in two modes per issue:

- `before-fix`: undoes the fix, then confirms the bug happens (green = reproduced)
- `after-fix`: runs the script as committed, then confirms everything works

Covered: `ubuntu-22.04`, `ubuntu-22.04-arm`, `ubuntu-24.04`, `ubuntu-24.04-arm`, `ubuntu-26.04` (control). The image tests, including the two new ones, run as part of the script in every leg.

> The affected images were rolled back, but the code on `main` still contains both bugs, so the next image build would reintroduce them.

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated