### PR TITLE
[Ubuntu] Pin vcpkg for CMake 3.31 compatibility

### DIFF
--- a/images/ubuntu/scripts/build/install-vcpkg.sh
+++ b/images/ubuntu/scripts/build/install-vcpkg.sh
@@ -6,6 +6,7 @@
 
 # Source the helpers for use with the script
 source $HELPER_SCRIPTS/etc-environment.sh
+source $HELPER_SCRIPTS/install.sh
 source $HELPER_SCRIPTS/os.sh
 
 if is_arm64; then
@@ -19,6 +20,10 @@ set_etc_environment_variable "VCPKG_INSTALLATION_ROOT" "${VCPKG_INSTALLATION_ROO
 
 # Install vcpkg
 git clone https://github.com/Microsoft/vcpkg $VCPKG_INSTALLATION_ROOT
+vcpkg_commit=$(get_toolset_value '.vcpkg.commit // empty')
+if [[ -n "$vcpkg_commit" ]]; then
+  git -C $VCPKG_INSTALLATION_ROOT checkout "$vcpkg_commit"
+fi
 
 $VCPKG_INSTALLATION_ROOT/bootstrap-vcpkg.sh
 

--- a/images/ubuntu/toolsets/toolset-2204-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2204-arm64.json
@@ -348,6 +348,14 @@
             "review-at": "2026-09-01"
         }
     },
+    "vcpkg": {
+        "commit": "827a2e1203bc19941126c657166da44f2623acc4",
+        "pinnedDetails": {
+            "reason": "Pinned to a version compatible with CMake 3.31.6",
+            "link": "https://github.com/microsoft/vcpkg/commit/827a2e1203bc19941126c657166da44f2623acc4",
+            "review-at": "2026-09-01"
+        }
+    },
     "pwsh": {
         "version": "7.4"
     }

--- a/images/ubuntu/toolsets/toolset-2404-arm64.json
+++ b/images/ubuntu/toolsets/toolset-2404-arm64.json
@@ -325,6 +325,14 @@
             "review-at": "2026-09-01"
         }
     },
+    "vcpkg": {
+        "commit": "827a2e1203bc19941126c657166da44f2623acc4",
+        "pinnedDetails": {
+            "reason": "Pinned to a version compatible with CMake 3.31.6",
+            "link": "https://github.com/microsoft/vcpkg/commit/827a2e1203bc19941126c657166da44f2623acc4",
+            "review-at": "2026-09-01"
+        }
+    },
     "pwsh": {
         "version": "7.4"
     }


### PR DESCRIPTION
# Description

**Bug fixing**

Ubuntu 22.04 and 24.04 Arm64 canary runs started failing the
`vcpkg arm64-linux` test after the bootstrapped vcpkg tool moved from
`2026-07-13-bf04c909...` to `2026-07-27-98d7cb0...`.

Arm64 images set `VCPKG_FORCE_SYSTEM_BINARIES=1`, so vcpkg uses the CMake
version installed on the image. Ubuntu 22.04 and 24.04 intentionally pin CMake
to 3.31.6, while the updated vcpkg scripts call
`string(JSON ... STRING_ENCODE)`, which was added in CMake 4.3. As a result,
vcpkg fails while installing `sqlite3:arm64-linux`; the subsequent missing
`unofficial-sqlite3Config.cmake` error is only a cascade from that failure.

This change:
- Adds support for an optional `.vcpkg.commit` value in Ubuntu toolsets
- Checks out that revision before running `bootstrap-vcpkg.sh`
- Pins Ubuntu 22.04 and 24.04 Arm64 to the last known compatible vcpkg commit,
  `827a2e1203bc19941126c657166da44f2623acc4`
- Records the reason and review date in `pinnedDetails`
- Leaves Ubuntu x64 and Ubuntu 26.04 on the current vcpkg revision

Pinning vcpkg keeps the fix scoped to the affected Arm64 images. Updating CMake
to 4.3 or later would also resolve `STRING_ENCODE`, but Ubuntu 22.04 and 24.04
currently stay on CMake 3.31.6 to avoid known CMake 4 compatibility issues.

Failure examples:
- https://github.com/github/hosted-runners-images/actions/runs/30854309554
- https://github.com/github/hosted-runners-images/actions/runs/30854305346

#### Related issue:
- Fixes https://github.com/github/hosted-runners-images/issues/892

## Testing
- [Ubuntu 24.04 Arm64 HRI build](https://github.com/github/hosted-runners-images/actions/runs/30897579743)
  completed successfully using commit `182c9f1fbc3a3d1516ffe72fccfd3096b5140743`
- [Ubuntu 22.04 Arm64 HRI build](https://github.com/github/hosted-runners-images/actions/runs/30897576763)
  successfully generated and provisioned the image using the same fix commit