### PR TITLE
[Ubuntu] Remove podman bundle's non-setuid fusermount3 that breaks unprivileged FUSE mounts- #14517

### DIFF
--- a/images/ubuntu/scripts/build/install-container-tools.sh
+++ b/images/ubuntu/scripts/build/install-container-tools.sh
@@ -56,6 +56,11 @@ install_podman_static() {
     printf '[engine.runtimes]\ncrun = ["/usr/local/bin/crun"]\n' \
         | tee /etc/containers/containers.conf.d/00-fix-runtime.conf
 
+    # The bundle's non-setuid fusermount3 shadows the distro's setuid
+    # /usr/bin/fusermount3 (PATH order) and breaks unprivileged FUSE mounts.
+    # https://github.com/actions/runner-images/issues/14516
+    rm -f /usr/local/bin/fusermount3
+
     # Ubuntu >= 23.10 restricts unprivileged user namespaces via AppArmor
     # (kernel.apparmor_restrict_unprivileged_userns=1). The distro podman package
     # ships an /etc/apparmor.d/podman profile that grants the `userns` permission,

--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -346,6 +346,11 @@ Describe "Containers" {
         $(stat -c "%U" $Directory) | Should -Be "root"
     }
 
+    # https://github.com/actions/runner-images/issues/14516
+    It "fusermount3 resolves to the setuid distro helper, not the podman bundle shadow" -Skip:(Test-IsUbuntu26) {
+        (Get-Command fusermount3).Source | Should -Be "/usr/bin/fusermount3"
+    }
+
 }
 
 Describe "nvm" {


### PR DESCRIPTION
# Description

**Bug fix**

Unprivileged FUSE mounts (`sshfs`, `rclone`, `fuse-overlayfs`, AppImage, …) fail with `EPERM` on Ubuntu 22.04/24.04 when run as the `runner` user:

```
fusermount3: mount failed: Operation not permitted
```

**Cause:** the static `podman` bundle added in #14412 ships `/usr/local/bin/fusermount3` (mode `0755`, **not setuid**). Since `/usr/local/bin` precedes `/usr/bin` in `PATH`, it shadows the distro's setuid-root `/usr/bin/fusermount3`, so the helper runs without privileges. Ubuntu 26.04 is unaffected (no bundle).

**Fix** — `images/ubuntu/scripts/build/install-container-tools.sh`: remove the bundle's `/usr/local/bin/fusermount3` so the setuid distro helper is used (`fuse-overlayfs` still resolves it via `PATH`). Added a `Containers` regression test asserting `fusermount3` resolves to `/usr/bin/fusermount3`. Complements #14480, which did not touch `fusermount3`.

#### Related issue:
- Fixes https://github.com/actions/runner-images/issues/14516

## Check list
- [x] Related issue / work item is attached
- [x] Tests are written (if applicable) — `Containers` regression test for the `fusermount3` path
- [x] Documentation is updated (if applicable) — n/a
- [ ] Changes are tested and related VM images are successfully generated

### Build results

| Image | Status | Link |
|---|---|---|
| Ubuntu 22.04 X64 | IN PROGRESS | https://github.com/actions/runner-images-ci/actions/runs/31171442196 |
| Ubuntu 24.04 X64 | IN PROGRESS | https://github.com/actions/runner-images-ci/actions/runs/31171444735 |
